### PR TITLE
tileToLayout for RasterSource

### DIFF
--- a/vlm/src/main/scala/geotrellis/contrib/vlm/GeoTiffResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/GeoTiffResampleRasterSource.scala
@@ -70,6 +70,9 @@ class GeoTiffResampleRasterSource(
   override def readBounds(bounds: Traversable[GridBounds], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
     val geoTiffTile = closetTiffOverview.tile.asInstanceOf[GeoTiffMultibandTile]
 
+    println(s"\nThis is the extent of the overview: ${closestTiffOverview.extent}")
+    println(s"This is the cellSize of the overview: ${closestTiffOverview.raster.cellSize}")
+
     val windows = { for {
       queryPixelBounds <- bounds
       targetPixelBounds <- queryPixelBounds.intersection(this)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/GeoTiffResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/GeoTiffResampleRasterSource.scala
@@ -70,9 +70,6 @@ class GeoTiffResampleRasterSource(
   override def readBounds(bounds: Traversable[GridBounds], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
     val geoTiffTile = closestTiffOverview.tile.asInstanceOf[GeoTiffMultibandTile]
 
-    println(s"\nThis is the extent of the overview: ${closestTiffOverview.extent}")
-    println(s"This is the cellSize of the overview: ${closestTiffOverview.raster.cellSize}")
-
     val windows = { for {
       queryPixelBounds <- bounds
       targetPixelBounds <- queryPixelBounds.intersection(this)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/GeoTiffResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/GeoTiffResampleRasterSource.scala
@@ -40,7 +40,7 @@ class GeoTiffResampleRasterSource(
   override lazy val rasterExtent =
     resampleGrid(tiff.rasterExtent)
 
-  @transient lazy val closetTiffOverview: GeoTiff[MultibandTile] =
+  @transient lazy val closestTiffOverview: GeoTiff[MultibandTile] =
     tiff.getClosestOverview(rasterExtent.cellSize, AutoHigherResolution)
 
   def reproject(targetCRS: CRS, options: Reproject.Options): GeoTiffReprojectRasterSource =
@@ -68,7 +68,7 @@ class GeoTiffResampleRasterSource(
   }
 
   override def readBounds(bounds: Traversable[GridBounds], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
-    val geoTiffTile = closetTiffOverview.tile.asInstanceOf[GeoTiffMultibandTile]
+    val geoTiffTile = closestTiffOverview.tile.asInstanceOf[GeoTiffMultibandTile]
 
     println(s"\nThis is the extent of the overview: ${closestTiffOverview.extent}")
     println(s"This is the cellSize of the overview: ${closestTiffOverview.raster.cellSize}")
@@ -78,7 +78,7 @@ class GeoTiffResampleRasterSource(
       targetPixelBounds <- queryPixelBounds.intersection(this)
     } yield {
       val targetExtent = rasterExtent.extentFor(targetPixelBounds)
-      val sourcePixelBounds = closetTiffOverview.rasterExtent.gridBoundsFor(targetExtent, clamp = true)
+      val sourcePixelBounds = closestTiffOverview.rasterExtent.gridBoundsFor(targetExtent, clamp = true)
       val targetRasterExtent = RasterExtent(targetExtent, targetPixelBounds.width, targetPixelBounds.height)
       (sourcePixelBounds, targetRasterExtent)
     }}.toMap

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/LayoutTileSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/LayoutTileSource.scala
@@ -102,6 +102,9 @@ class LayoutTileSource(val source: RasterSource, val layout: LayoutDefinition) {
 }
 
 object LayoutTileSource {
+  def apply(source: RasterSource, layout: LayoutDefinition): LayoutTileSource =
+    new LayoutTileSource(source, layout)
+
   private def requireGridAligned(a: GridExtent, b: GridExtent): Unit = {
     import org.scalactic._
     import TripleEquals._

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
@@ -21,6 +21,8 @@ import geotrellis.raster._
 import geotrellis.raster.resample._
 import geotrellis.raster.reproject.Reproject
 import geotrellis.proj4._
+import geotrellis.spark.tiling.LayoutDefinition
+
 import cats.effect.IO
 import java.net.URI
 
@@ -154,4 +156,16 @@ trait RasterSource extends CellGrid with Serializable {
       */
     def readBounds(bounds: Traversable[GridBounds]): Iterator[Raster[MultibandTile]] =
         bounds.toIterator.flatMap(read(_, (0 until bandCount)).toIterator)
+
+    /**
+     * Applies the given [[LayoutDefinition]] to the source data producing a [[LayoutTileSource]].
+     * In order to fit to the given layout, the source data is resampled to match the Extent
+     * and CellSize of the layout.
+     *
+     */
+    def tileToLayout(layout: LayoutDefinition, resampleMethod: ResampleMethod = NearestNeighbor): LayoutTileSource =
+      LayoutTileSource(
+        resampleToGrid(GridExtent(layout.extent, layout.cellwidth, layout.cellheight), resampleMethod),
+        layout
+      )
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
@@ -164,8 +164,5 @@ trait RasterSource extends CellGrid with Serializable {
      *
      */
     def tileToLayout(layout: LayoutDefinition, resampleMethod: ResampleMethod = NearestNeighbor): LayoutTileSource =
-      LayoutTileSource(
-        resampleToGrid(GridExtent(layout.extent, layout.cellwidth, layout.cellheight), resampleMethod),
-        layout
-      )
+      LayoutTileSource(resampleToGrid(layout, resampleMethod), layout)
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
@@ -23,9 +23,6 @@ import geotrellis.raster.reproject.Reproject
 import geotrellis.proj4._
 import geotrellis.spark.tiling.LayoutDefinition
 
-import cats.effect.IO
-import java.net.URI
-
 /**
   * Single threaded instance of a reader that is able to read windows from larger raster.
   * Some initilization step is expected to provide metadata about source raster
@@ -165,4 +162,6 @@ trait RasterSource extends CellGrid with Serializable {
      */
     def tileToLayout(layout: LayoutDefinition, resampleMethod: ResampleMethod = NearestNeighbor): LayoutTileSource =
       LayoutTileSource(resampleToGrid(layout, resampleMethod), layout)
+
+    def close = { }
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/ResampleGrid.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/ResampleGrid.scala
@@ -28,7 +28,7 @@ case class Dimensions(cols: Int, rows: Int) extends ResampleGrid {
 }
 
 case class TargetGrid(grid: GridExtent) extends ResampleGrid {
-  def apply(source: RasterExtent): RasterExtent = 
+  def apply(source: RasterExtent): RasterExtent =
     grid.createAlignedRasterExtent(source.extent)
 }
 

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALBaseRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALBaseRasterSource.scala
@@ -111,4 +111,6 @@ trait GDALBaseRasterSource extends RasterSource {
     val bounds = extents.map(rasterExtent.gridBoundsFor(_, clamp = false))
     readBounds(bounds, 0 until bandCount)
   }
+
+  override def close = dataset.delete()
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALReprojectRasterSource.scala
@@ -39,6 +39,7 @@ case class GDALReprojectRasterSource(
         resampleMethod = options.method.some,
         errorThreshold = options.errorThreshold.some,
         cellSize       = cellSize,
+        alignTargetPixels = true,
         sourceCRS      = baseSpatialReference.some,
         targetCRS      = targetSpatialReference.some
       )

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALResampleRasterSource.scala
@@ -47,6 +47,7 @@ case class GDALResampleRasterSource(
           val targetRasterExtent = resampleGrid(rasterExtent)
           GDALWarpOptions(
             cellSize = targetRasterExtent.cellSize.some,
+            alignTargetPixels = false,
             resampleMethod = method.some
           )
       }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALWarpOptions.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALWarpOptions.scala
@@ -30,10 +30,8 @@ case class GDALWarpOptions(
     errorThreshold.toList.flatMap { et => List("-et", s"${et}") } :::
     cellSize.toList.flatMap { cz =>
       // the -tap parameter can only be set if -tr is set as well
-      if (alignTargetPixels)
-        List("-tap", "-tr", s"${cz.width}", s"${cz.height}")
-      else
-        List("-tr", s"${cz.width}", s"${cz.height}")
+      val tr = List("-tr", s"${cz.width}", s"${cz.height}")
+      if (alignTargetPixels) "-tap" +: tr else tr
     } :::
     dimensions.toList.flatMap { case (c, r) => List("-ts", s"$c", s"$r") } :::
     (sourceCRS, targetCRS).mapN { (source, target) =>

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/GeoTiffRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/GeoTiffRasterSourceSpec.scala
@@ -85,10 +85,8 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRas
   it("should perform a tileToLayout") {
     val targetCellSize: CellSize = CellSize(20.0, 20.0)
 
-    val testSource: MultibandGeoTiff =
-      GeoTiffReader.readMultiband(url, streaming = false)
-
-    val testTile = testSource.tile
+    val testSource: MultibandGeoTiff = GeoTiffReader.readMultiband(url)
+    val testTile = testSource.tile.toArrayTile
 
     val pe = ProjectedExtent(testSource.extent, testSource.crs)
 
@@ -120,8 +118,8 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRas
     println(s"\nThis is the actual extent: ${result.source.extent}")
     println(s"This is the actual cellSize: ${result.source.cellSize}")
 
-    //println(s"This is the count for expected: ${expected.size}")
-    //println(s"This is the count for actual: ${actual.size}")
+    println(s"This is the count for expected: ${expected.size}")
+    println(s"This is the count for actual: ${actual.size}")
 
     actual.size should be (expected.size)
 

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/GeoTiffRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/GeoTiffRasterSourceSpec.scala
@@ -17,24 +17,16 @@
 package geotrellis.contrib.vlm
 
 import geotrellis.raster._
-import geotrellis.raster.prototype._
-import geotrellis.raster.merge._
 import geotrellis.raster.io.geotiff.MultibandGeoTiff
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.resample._
-import geotrellis.raster.reproject._
 import geotrellis.raster.testkit._
-import geotrellis.vector.{Extent, ProjectedExtent}
-import geotrellis.proj4._
+import geotrellis.vector._
 import geotrellis.spark._
 import geotrellis.spark.tiling._
-import geotrellis.spark.testkit._
 import geotrellis.util._
 
 import org.scalatest._
-
-import java.io.File
-
 
 class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRasterMatchers with GivenWhenThen {
   val url = Resource.path("img/aspect-tiled.tif")
@@ -85,7 +77,7 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRas
   it("should perform a tileToLayout") {
     val targetCellSize: CellSize = CellSize(20.0, 20.0)
 
-    val testSource: MultibandGeoTiff = GeoTiffReader.readMultiband(url)
+    val testSource = GeoTiffReader.readMultiband(url).getClosestOverview(targetCellSize)
     val testTile = testSource.tile.toArrayTile
 
     val pe = ProjectedExtent(testSource.extent, testSource.crs)
@@ -136,7 +128,7 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRas
     val grouped: List[(Raster[MultibandTile], Raster[MultibandTile])] =
       sortedActual.zip(sortedExpected)
 
-    grouped.map { case (actualTile, expectedTile) =>
+    grouped.foreach { case (actualTile, expectedTile) =>
       withGeoTiffClue(actualTile, expectedTile, source.crs)  {
         assertRastersEqual(actualTile, expectedTile)
       }

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/GeoTiffRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/GeoTiffRasterSourceSpec.scala
@@ -74,50 +74,63 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRas
     }
   }
 
-  it("should perform a tileToLayout") {
-    val targetCellSize: CellSize = CellSize(11.0, 11.0)
-    val pe = ProjectedExtent(source.extent, source.crs)
-    val scheme = FloatingLayoutScheme(256)
-    val layout = scheme.levelFor(pe.extent, targetCellSize).layout
-    val mapTransform = layout.mapTransform
-    val resampledSource = source.resampleToGrid(layout)
-
-    val expected: List[(SpatialKey, MultibandTile)] =
-      mapTransform(pe.extent).coordsIter.map { spatialComponent =>
-        val key = pe.translate(spatialComponent)
-        val ext = mapTransform.keyToExtent(key.getComponent[SpatialKey])
-        val raster = resampledSource.read(ext).get
-        val newTile = raster.tile.prototype(source.cellType, layout.tileCols, layout.tileRows)
-        key -> newTile.merge(
-          ext,
-          raster.extent,
-          raster.tile,
-          NearestNeighbor
-        )
-      }.toList
-
-    val actual: List[(SpatialKey, MultibandTile)] = source.tileToLayout(layout).readAll().toList
-
-    withClue(s"actual.size: ${actual.size} expected.size: ${expected.size}") {
-      actual.size should be (expected.size)
+  describe("should perform a tileToLayout") {
+    val cellSizes = {
+      val tiff = GeoTiffReader.readMultiband(url)
+      (tiff +: tiff.overviews).map(_.rasterExtent.cellSize).map { case CellSize(w, h) =>
+        CellSize(w + 1, h + 1)
+      }
     }
 
-   val sortedActual: List[Raster[MultibandTile]] =
-     actual
-       .sortBy { case (k, _) => (k.col, k.row) }
-       .map { case (k, v) => Raster(v, mapTransform.keyToExtent(k)) }
+    cellSizes.foreach { targetCellSize =>
+      it(s"should perform a tileToLayout for cellSize: ${targetCellSize}") {
+        val pe = ProjectedExtent(source.extent, source.crs)
+        val scheme = FloatingLayoutScheme(256)
+        val layout = scheme.levelFor(pe.extent, targetCellSize).layout
+        val mapTransform = layout.mapTransform
+        val resampledSource = source.resampleToGrid(layout)
 
-   val sortedExpected: List[Raster[MultibandTile]] =
-     expected
-       .sortBy { case (k, _) => (k.col, k.row) }
-       .map { case (k, v) => Raster(v, mapTransform.keyToExtent(k)) }
+        val expected: List[(SpatialKey, MultibandTile)] =
+          mapTransform(pe.extent).coordsIter.map { spatialComponent =>
+            val key = pe.translate(spatialComponent)
+            val ext = mapTransform.keyToExtent(key.getComponent[SpatialKey])
+            val raster = resampledSource.read(ext).get
+            val newTile = raster.tile.prototype(source.cellType, layout.tileCols, layout.tileRows)
+            key -> newTile.merge(
+              ext,
+              raster.extent,
+              raster.tile,
+              NearestNeighbor
+            )
+          }.toList
 
-    val grouped: List[(Raster[MultibandTile], Raster[MultibandTile])] =
-      sortedActual.zip(sortedExpected)
+        val layoutSource = source.tileToLayout(layout)
+        val actual: List[(SpatialKey, MultibandTile)] = layoutSource.readAll().toList
 
-    grouped.foreach { case (actualTile, expectedTile) =>
-      withGeoTiffClue(actualTile, expectedTile, source.crs)  {
-        assertRastersEqual(actualTile, expectedTile)
+        withClue(s"actual.size: ${actual.size} expected.size: ${expected.size}") {
+          actual.size should be(expected.size)
+        }
+
+        val sortedActual: List[Raster[MultibandTile]] =
+          actual
+            .sortBy { case (k, _) => (k.col, k.row) }
+            .map { case (k, v) => Raster(v, mapTransform.keyToExtent(k)) }
+
+        val sortedExpected: List[Raster[MultibandTile]] =
+          expected
+            .sortBy { case (k, _) => (k.col, k.row) }
+            .map { case (k, v) => Raster(v, mapTransform.keyToExtent(k)) }
+
+        val grouped: List[(Raster[MultibandTile], Raster[MultibandTile])] =
+          sortedActual.zip(sortedExpected)
+
+        grouped.foreach { case (actualTile, expectedTile) =>
+          withGeoTiffClue(actualTile, expectedTile, source.crs) {
+            assertRastersEqual(actualTile, expectedTile)
+          }
+        }
+
+        layoutSource.source
       }
     }
   }

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/GeoTiffRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/GeoTiffRasterSourceSpec.scala
@@ -75,7 +75,7 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRas
   }
 
   it("should perform a tileToLayout") {
-    val targetCellSize: CellSize = CellSize(20.0, 20.0)
+    val targetCellSize: CellSize = CellSize(19.0, 19.0)
 
     val testSource = GeoTiffReader.readMultiband(url).getClosestOverview(targetCellSize)
     val testTile = testSource.tile.toArrayTile
@@ -88,7 +88,8 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRas
 
     val expected: List[(SpatialKey, MultibandTile)] =
       mapTransform(pe.extent)
-        .coordsIter.map { spatialComponent =>
+        .coordsIter
+        .map { spatialComponent =>
           val key = pe.translate(spatialComponent)
           val newTile = testTile.prototype(source.cellType, layout.tileCols, layout.tileRows)
           (key,
@@ -101,19 +102,11 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRas
           )
         }.toList
 
-    val result = source.tileToLayout(layout)
-    //val actual: List[(SpatialKey, MultibandTile)] = source.tileToLayout(layout).readAll().toList
-    val actual: List[(SpatialKey, MultibandTile)] = result.readAll().toList
+    val actual: List[(SpatialKey, MultibandTile)] = source.tileToLayout(layout).readAll().toList
 
-    println(s"\nThis is the layout extent: ${layout.extent}")
-    println(s"This is the layout extent: ${layout.cellwidth}, ${layout.cellheight}")
-    println(s"\nThis is the actual extent: ${result.source.extent}")
-    println(s"This is the actual cellSize: ${result.source.cellSize}")
-
-    println(s"This is the count for expected: ${expected.size}")
-    println(s"This is the count for actual: ${actual.size}")
-
-    actual.size should be (expected.size)
+    withClue(s"actual.size: ${actual.size} expected.size: ${expected.size}") {
+      actual.size should be (expected.size)
+    }
 
    val sortedActual: List[Raster[MultibandTile]] =
      actual
@@ -133,28 +126,5 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRas
         assertRastersEqual(actualTile, expectedTile)
       }
     }
-
-    //println("\nThese are the expected keys")
-    //expected.sortBy { case (key, _) => (key.col, key.row) }.foreach { case (k, _) => println(k) }
-    //println("\nThese are the actual keys")
-    //actual.sortBy { case (key, _) => (key.col, key.row) }.foreach { case (k, _) => println(k) }
-
-    /*
-    val grouped: List[(Raster[MultibandTile], Raster[MultibandTile])] =
-      actual
-        .sortBy { case (k, _) => (k.col, k.row) }
-        .map { case (k, v) => Raster(v, mapTransform.keyToExtent(k)) }
-        .zip(
-          expected
-            .sortBy { case (k, _) => (k.col, k.row) }
-            .map { case (k, v) => Raster(v, mapTransform.keyToExtent(k)) }
-        )
-
-    grouped.map { case (actualTile, expectedTile) =>
-      withGeoTiffClue(actualTile, expectedTile, source.crs)  {
-        assertRastersEqual(actualTile, expectedTile)
-      }
-    }
-    */
   }
 }

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALRasterSourceSpec.scala
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-package geotrellis.contrib.vlm
+package geotrellis.contrib.vlm.gdal
 
-import geotrellis.contrib.vlm.gdal._
+import geotrellis.contrib.vlm._
 import geotrellis.raster._
-import geotrellis.raster.prototype._
-import geotrellis.raster.merge._
 import geotrellis.raster.io.geotiff.MultibandGeoTiff
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.resample._
 import geotrellis.raster.testkit._
-import geotrellis.vector.{Extent, ProjectedExtent}
+import geotrellis.vector._
 import geotrellis.spark._
 import geotrellis.spark.tiling._
 import geotrellis.util._
@@ -87,10 +85,8 @@ class GDALRasterSourceSpec extends FunSpec with RasterMatchers with BetterRaster
   it("should perform a tileToLayout") {
     val targetCellSize: CellSize = CellSize(11.0, 11.0)
 
-    val testSource: MultibandGeoTiff =
-      GeoTiffReader.readMultiband(url, streaming = false)
-
-    val testTile = testSource.tile
+    val testSource: MultibandGeoTiff = GeoTiffReader.readMultiband(url)
+    val testTile = testSource.tile.toArrayTile
 
     val pe = ProjectedExtent(testSource.extent, testSource.crs)
 
@@ -131,7 +127,7 @@ class GDALRasterSourceSpec extends FunSpec with RasterMatchers with BetterRaster
     val grouped: List[(Raster[MultibandTile], Raster[MultibandTile])] =
       sortedActual.zip(sortedExpected)
 
-    grouped.map { case (actualTile, expectedTile) =>
+    grouped.foreach { case (actualTile, expectedTile) =>
       withGeoTiffClue(actualTile, expectedTile, source.crs)  {
         assertRastersEqual(actualTile, expectedTile)
       }

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALRasterSourceSpec.scala
@@ -18,9 +18,17 @@ package geotrellis.contrib.vlm
 
 import geotrellis.contrib.vlm.gdal._
 import geotrellis.raster._
+import geotrellis.raster.prototype._
+import geotrellis.raster.merge._
+import geotrellis.raster.io.geotiff.MultibandGeoTiff
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.resample._
 import geotrellis.raster.testkit._
+import geotrellis.vector.{Extent, ProjectedExtent}
+import geotrellis.spark._
+import geotrellis.spark.tiling._
+import geotrellis.util._
+
 import org.scalatest._
 
 class GDALRasterSourceSpec extends FunSpec with RasterMatchers with BetterRasterMatchers with GivenWhenThen {
@@ -73,6 +81,65 @@ class GDALRasterSourceSpec extends FunSpec with RasterMatchers with BetterRaster
 
     withGeoTiffClue(actual, expected, resampledSource.crs)  {
       assertRastersEqual(actual, expected)
+    }
+  }
+
+  it("should perform a tileToLayout") {
+    val targetCellSize: CellSize = CellSize(20.0, 20.0)
+    val targetExtent: Extent = source.extent.buffer(10.0)
+
+    val scheme = FloatingLayoutScheme(256)
+    val layout = scheme.levelFor(targetExtent, targetCellSize).layout
+    val mapTransform = layout.mapTransform
+
+    val testSource: MultibandGeoTiff =
+      GeoTiffReader.readMultiband(url, streaming = false)
+
+    val testTile = testSource.tile
+
+    val pe = ProjectedExtent(testSource.extent, testSource.crs)
+
+    val expected: List[(SpatialKey, MultibandTile)] =
+      mapTransform(pe.extent)
+        .coordsIter.map { spatialComponent =>
+          val key = pe.translate(spatialComponent)
+          val newTile = testTile.prototype(source.cellType, layout.tileCols, layout.tileRows)
+          (key,
+            newTile.merge(
+              mapTransform.keyToExtent(key.getComponent[SpatialKey]),
+              pe.extent,
+              testTile,
+              NearestNeighbor
+            )
+          )
+        }.toList
+
+    val actual: List[(SpatialKey, MultibandTile)] = source.tileToLayout(layout).readAll().toList
+
+    println(s"This is the count for expected: ${expected.size}")
+    println(s"This is the count for actual: ${actual.size}")
+
+    actual.size should be (expected.size)
+
+    println("\nThese are the expected keys")
+    expected.sortBy { case (key, _) => (key.col, key.row) }.foreach { case (k, _) => println(k) }
+    println("\nThese are the actual keys")
+    actual.sortBy { case (key, _) => (key.col, key.row) }.foreach { case (k, _) => println(k) }
+
+    val grouped: List[(Raster[MultibandTile], Raster[MultibandTile])] =
+      actual
+        .sortBy { case (k, _) => (k.col, k.row) }
+        .map { case (k, v) => Raster(v, mapTransform.keyToExtent(k)) }
+        .zip(
+          expected
+            .sortBy { case (k, _) => (k.col, k.row) }
+            .map { case (k, v) => Raster(v, mapTransform.keyToExtent(k)) }
+        )
+
+    grouped.map { case (actualTile, expectedTile) =>
+      withGeoTiffClue(actualTile, expectedTile, source.crs)  {
+        assertRastersEqual(actualTile, expectedTile)
+      }
     }
   }
 }

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALRasterSourceSpec.scala
@@ -112,7 +112,9 @@ class GDALRasterSourceSpec extends FunSpec with RasterMatchers with BetterRaster
 
     val actual: List[(SpatialKey, MultibandTile)] = source.tileToLayout(layout).readAll().toList
 
-    actual.size should be (expected.size)
+    withClue(s"actual.size: ${actual.size} expected.size: ${expected.size}") {
+      actual.size should be (expected.size)
+    }
 
    val sortedActual: List[Raster[MultibandTile]] =
      actual

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALReaderSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALReaderSpec.scala
@@ -16,8 +16,8 @@ class GDALReaderSpec
   describe("GDALReaderSpec") {
     it("should read full raster correct") {
       val filePath = s"${new File("").getAbsolutePath()}/src/test/resources/img/aspect-tiled.tif"
-      val gdalTile = GDALReader(filePath).read()
-      val gtTile   = GeoTiffReader.readMultiband(filePath).tile
+      val gdalTile = GDALReader(filePath).read().toArrayTile
+      val gtTile   = GeoTiffReader.readMultiband(filePath).tile.toArrayTile
 
       assertEqual(gdalTile, gtTile)
     }


### PR DESCRIPTION
This PR adds the `tileToLayout` method to `RasterSource` which will allow users to apply a layout on their source data.

Resolves #30 