### PR TITLE
0.3.0-SNAPSHOT Release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val vlm = project
   .settings(
     organization := "com.azavea.geotrellis",
     name := "geotrellis-contrib-vlm",
-    version := "0.2.0",
+    version := "0.3.0-SNAPSHOT",
     libraryDependencies ++= Seq(
       geotrellisSpark,
       geotrellisS3,


### PR DESCRIPTION
This PR bumps the version number of geotrellis vlm from `0.2.0` to `0.3.0-SNAPSHOT`