### PR TITLE
Add a pixelAlignment flag

### DIFF
--- a/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
@@ -137,6 +137,18 @@ trait RasterSource extends CellGrid with AutoCloseable with Serializable {
     /**
       * @group read
       */
+    def read: Option[Raster[MultibandTile]] =
+        read(extent, (0 until bandCount))
+
+    /**
+      * @group read
+      */
+    def read(bands: Seq[Int]): Option[Raster[MultibandTile]] =
+        read(extent, bands)
+
+    /**
+      * @group read
+      */
     def readExtents(extents: Traversable[Extent], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
         extents.toIterator.flatMap(read(_, bands).toIterator)
 

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALRasterSource.scala
@@ -18,7 +18,7 @@ package geotrellis.contrib.vlm.gdal
 
 import geotrellis.raster.resample.ResampleMethod
 
-case class GDALRasterSource(uri: String) extends GDALBaseRasterSource {
+case class GDALRasterSource(uri: String, alignTargetPixels: Boolean = true) extends GDALBaseRasterSource {
   val baseWarpList: List[GDALWarpOptions] = Nil
   def resampleMethod: Option[ResampleMethod] = None
   lazy val warpOptions: GDALWarpOptions = GDALWarpOptions()

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALReprojectRasterSource.scala
@@ -28,7 +28,8 @@ case class GDALReprojectRasterSource(
   uri: String,
   targetCRS: CRS,
   options: Reproject.Options = Reproject.Options.DEFAULT,
-  baseWarpList: List[GDALWarpOptions] = Nil
+  baseWarpList: List[GDALWarpOptions] = Nil,
+  alignTargetPixels: Boolean = true
 ) extends GDALBaseRasterSource {
   def resampleMethod: Option[ResampleMethod] = options.method.some
 
@@ -56,7 +57,7 @@ case class GDALReprojectRasterSource(
       resampleMethod = options.method.some,
       errorThreshold = options.errorThreshold.some,
       cellSize = cellSize,
-      alignTargetPixels = true,
+      alignTargetPixels = alignTargetPixels,
       sourceCRS = baseSpatialReference.toCRS.some,
       targetCRS = targetSpatialReference.toCRS.some,
       srcNoData = noDataValue
@@ -66,8 +67,8 @@ case class GDALReprojectRasterSource(
   }
 
   override def reproject(targetCRS: CRS, options: Reproject.Options): RasterSource =
-    GDALReprojectRasterSource(uri, targetCRS, options, warpList)
+    GDALReprojectRasterSource(uri, targetCRS, options, warpList, alignTargetPixels)
 
   override def resample(resampleGrid: ResampleGrid, method: ResampleMethod): RasterSource =
-    GDALResampleRasterSource(uri, resampleGrid, method, warpList)
+    GDALResampleRasterSource(uri, resampleGrid, method, warpList, alignTargetPixels)
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALResampleRasterSource.scala
@@ -29,7 +29,8 @@ case class GDALResampleRasterSource(
   uri: String,
   resampleGrid: ResampleGrid,
   method: ResampleMethod = NearestNeighbor,
-  baseWarpList: List[GDALWarpOptions] = Nil
+  baseWarpList: List[GDALWarpOptions] = Nil,
+  alignTargetPixels: Boolean = true
 ) extends GDALBaseRasterSource {
   def resampleMethod: Option[ResampleMethod] = method.some
 
@@ -62,7 +63,7 @@ case class GDALResampleRasterSource(
         val targetRasterExtent = resampleGrid(rasterExtent)
         GDALWarpOptions(
           cellSize = targetRasterExtent.cellSize.some,
-          alignTargetPixels = false,
+          alignTargetPixels = alignTargetPixels,
           resampleMethod = resampleMethod,
           srcNoData = noDataValue
         )
@@ -72,8 +73,8 @@ case class GDALResampleRasterSource(
   }
 
   override def reproject(targetCRS: CRS, options: Reproject.Options): RasterSource =
-    GDALReprojectRasterSource(uri, targetCRS, options, warpList)
+    GDALReprojectRasterSource(uri, targetCRS, options, warpList, alignTargetPixels)
 
   override def resample(resampleGrid: ResampleGrid, method: ResampleMethod): RasterSource =
-    GDALResampleRasterSource(uri, resampleGrid, method, warpList)
+    GDALResampleRasterSource(uri, resampleGrid, method, warpList, alignTargetPixels)
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALWarpOptions.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALWarpOptions.scala
@@ -20,23 +20,65 @@ import geotrellis.raster._
 import geotrellis.raster.resample._
 import geotrellis.proj4.CRS
 import geotrellis.vector.Extent
+
 import cats.implicits._
 import org.gdal.gdal.WarpOptions
 
 import scala.collection.JavaConverters._
 
-// TODO: to implement the full coverage of the GDAL API here
+/**
+  * GDALWarpOptions basically should cover https://www.gdal.org/gdalwarp.html
+  *
+  * This is a basic implementation, we need to cover all the parameters in a future.
+  */
 case class GDALWarpOptions(
+  /** -of, Select the output format. The default is GeoTIFF (GTiff). Use the short format name. */
   outputFormat: Option[String] = Some("VRT"),
+  /** -r, Resampling method to use, visit https://www.gdal.org/gdalwarp.html for details. */
   resampleMethod: Option[ResampleMethod] = None,
+  /** -et, error threshold for transformation approximation */
   errorThreshold: Option[Double] = None,
+  /** -tr, set output file resolution (in target georeferenced units) */
   cellSize: Option[CellSize] = None,
+  /** -tap, aligns the coordinates of the extent of the output file to the values of the target resolution,
+    * such that the aligned extent includes the minimum extent.
+    *
+    * In terms of GeoTrellis it's very similar to [[GridExtent]].createAlignedGridExtent:
+    *
+    * newMinX = floor(envelop.minX / xRes) * xRes
+    * newMaxX = ceil(envelop.maxX / xRes) * xRes
+    * newMinY = floor(envelop.minY / yRes) * yRes
+    * newMaxY = ceil(envelop.maxY / yRes) * yRes
+    *
+    * if (xRes == 0) || (yRes == 0) than GDAL calculates it using the extent and the cellSize
+    * xRes = (maxX - minX) / cellSize.width
+    * yRes = (maxY - minY) / cellSize.height
+    *
+    * If -tap parameter is NOT set, GDAL increases extent by a half of a pixel, to avoid missing points on the border.
+    *
+    * The actual code reference: https://github.com/OSGeo/gdal/blob/v2.3.2/gdal/apps/gdal_rasterize_lib.cpp#L402-L461
+    * The actual part with the -tap logic: https://github.com/OSGeo/gdal/blob/v2.3.2/gdal/apps/gdal_rasterize_lib.cpp#L455-L461
+    *
+    * The initial PR that introduced that feature in GDAL 1.8.0: https://trac.osgeo.org/gdal/attachment/ticket/3772/gdal_tap.patch
+    * A discussion thread related to it: https://lists.osgeo.org/pipermail/gdal-dev/2010-October/thread.html#26209
+    *
+    */
   alignTargetPixels: Boolean = true,
-  dimensions: Option[(Int, Int)] = None,
+  dimensions: Option[(Int, Int)] = None, // -ts
+  /** -s_srs, source spatial reference set */
   sourceCRS: Option[CRS] = None,
+  /** -t_srs, target spatial reference set */
   targetCRS: Option[CRS] = None,
+  /** -te, set georeferenced extents of output file to be created (with a CRS specified) */
   te: Option[(Extent, CRS)] = None,
+  /** -srcnodata, set nodata masking values for input bands (different values can be supplied for each band) */
   srcNoData: Option[Double] = None,
+  /** -ovr,  To specify which overview level of source files must be used.
+    *        The default choice, AUTO, will select the overview level whose resolution is the closest to the target resolution.
+    *        Specify an integer value (0-based, i.e. 0=1st overview level) to select a particular level.
+    *        Specify AUTO-n where n is an integer greater or equal to 1, to select an overview level below the AUTO one.
+    *        Or specify NONE to force the base resolution to be used (can be useful if overviews have been generated with a low quality resampling method, and the warping is done using a higher quality resampling method).
+    */
   ovr: Option[String] = Some("AUTO")
 ) {
   lazy val name: String = toWarpOptionsList.map(_.toLowerCase).mkString("_")
@@ -64,4 +106,21 @@ case class GDALWarpOptions(
 
   def toWarpOptions: WarpOptions =
     new WarpOptions(new java.util.Vector(toWarpOptionsList.asJava))
+
+  def combine(that: GDALWarpOptions): GDALWarpOptions = {
+    if (that == this) this
+    else this.copy(
+      outputFormat orElse that.outputFormat,
+      resampleMethod orElse that.resampleMethod,
+      errorThreshold orElse that.errorThreshold,
+      cellSize orElse that.cellSize,
+      alignTargetPixels || that.alignTargetPixels,
+      dimensions orElse that.dimensions,
+      sourceCRS orElse that.sourceCRS,
+      targetCRS orElse that.targetCRS,
+      te orElse that.te,
+      srcNoData orElse that.srcNoData,
+      ovr orElse that.ovr
+    )
+  }
 }

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSummarySpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSummarySpec.scala
@@ -135,7 +135,7 @@ class RasterSummarySpec extends FunSpec with TestEnvironment with BetterRasterMa
     // TODO: the problem is in a GDAL -tap parameter usage
     // should be fixed
     // actually GDAL version of seqential computations work slower
-    ignore("should collect summary for a tiled to layout source") {
+    it("should collect summary for a tiled to layout source") {
       val inputPath = Resource.path("img/aspect-tiled.tif")
       val files = inputPath :: Nil
       val targetCRS = WebMercator
@@ -178,7 +178,6 @@ class RasterSummarySpec extends FunSpec with TestEnvironment with BetterRasterMa
     }
   }
 
-  // TODO: better API to close resources, it is x2 slower than GeoTiffRasterSources
   it("should create ContextRDD from RDD of GDALRasterSources") {
     val inputPath = Resource.path("img/aspect-tiled.tif")
     val files = inputPath :: Nil
@@ -207,7 +206,7 @@ class RasterSummarySpec extends FunSpec with TestEnvironment with BetterRasterMa
           iter.flatMap { rr => rr.raster.toSeq.flatMap(_.tile.bands) }
         } } // read rasters
 
-    val (metadata, zoom) = summary.toTileLayerMetadata(layoutLevel)
+    val (metadata, _) = summary.toTileLayerMetadata(layoutLevel)
     val contextRDD: MultibandTileLayerRDD[SpatialKey] = ContextRDD(tileRDD, metadata)
 
     val res = contextRDD.collect()
@@ -223,7 +222,7 @@ class RasterSummarySpec extends FunSpec with TestEnvironment with BetterRasterMa
     val targetCRS = WebMercator
     val method = Bilinear
     val layout = LayoutDefinition(GridExtent(Extent(-2.0037508342789244E7, -2.0037508342789244E7, 2.0037508342789244E7, 2.0037508342789244E7), 9.554628535647032, 9.554628535647032), 256)
-    val RasterExtent(Extent(exmin, eymin, exmax, eymax), ecw, ech, ecols, erows) = GridExtent(Extent(-8769150.640916323, 4257706.177727701, -8750633.77081424, 4274455.441550691),9.554628535646703,9.554628535647199).toRasterExtent
+    val RasterExtent(Extent(exmin, eymin, exmax, eymax), ecw, ech, ecols, erows) = GridExtent(Extent(-8769152.078360025, 4257704.9041694235, -8750635.208257942, 4274463.722620948),9.554628535646703,9.554628535646929).toRasterExtent
 
     cfor(0)(_ < 11, _ + 1) { _ =>
       val reference = GDALRasterSource(inputPath).reproject(targetCRS, method).tileToLayout(layout, method)

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALRasterSourceSpec.scala
@@ -18,7 +18,6 @@ package geotrellis.contrib.vlm.gdal
 
 import geotrellis.contrib.vlm._
 import geotrellis.raster._
-import geotrellis.raster.io.geotiff.MultibandGeoTiff
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.resample._
 import geotrellis.raster.testkit._
@@ -33,7 +32,9 @@ class GDALRasterSourceSpec extends FunSpec with RasterMatchers with BetterRaster
   val url = Resource.path("img/aspect-tiled.tif")
   val uri = s"file://$url"
 
-  val source: GDALRasterSource = GDALRasterSource(uri)
+  // we are going to use this source for resampling into weird resolutions, let's check it
+  // usually we align pixels
+  val source: GDALRasterSource = GDALRasterSource(uri, alignTargetPixels = false)
 
   it("should be able to read upper left corner") {
     val bounds = GridBounds(0, 0, 10, 10)


### PR DESCRIPTION
`-tap just aligns the grid to the resolution`, so probably we don't need it always, as sometimes it can round extent incorrectly.

Fixes https://github.com/geotrellis/geotrellis-contrib/issues/45