### PR TITLE
Depend on a new GDAL version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ import sbt._
 
 object Version {
   val geotrellis     = "3.0.0-SNAPSHOT"
-  val geotrellisGdal = "0.16.4"
+  val geotrellisGdal = "0.16.6"
   val scala          = "2.11.12"
   val crossScala     = Seq(scala, "2.12.8")
   val hadoop         = "2.8.0"

--- a/vlm/src/main/resources/reference.conf
+++ b/vlm/src/main/resources/reference.conf
@@ -1,7 +1,13 @@
-gdal.cache {
-  maximumSize: 1000
-  enableDefaultRemovalListener: true
-  valuesType: Weak
-  enabled: true
-  withShutdownHook: true
+gdal {
+  options {
+    maxDatasetPoolSize: 1
+    vrtSharedSource: false
+  }
+  cache {
+    maximumSize: 100
+    enableDefaultRemovalListener: true
+    valuesType: Weak
+    enabled: true
+    withShutdownHook: true
+  }
 }

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSourceRDDSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSourceRDDSpec.scala
@@ -34,7 +34,7 @@ import java.io.File
 class RasterSourceRDDSpec extends FunSpec with TestEnvironment with BetterRasterMatchers with BeforeAndAfterAll {
   val filePath = s"${new File("").getAbsolutePath()}/src/test/resources/img/aspect-tiled.tif"
   val uri = s"file://$filePath"
-  val rasterSource = new GeoTiffRasterSource(uri)
+  val rasterSource = GeoTiffRasterSource(uri)
   val targetCRS = CRS.fromEpsgCode(3857)
   val scheme = ZoomedLayoutScheme(targetCRS)
   val layout = scheme.levelForZoom(13).layout
@@ -69,10 +69,10 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with BetterRaster
 
       forAll(rows) { case (key, tile) =>
         withClue(s"$key") {
-          tile should have (
-            dimensions (256, 256),
-            cellType (rasterSource.cellType),
-            bandCount (rasterSource.bandCount)
+          tile should have(
+            dimensions(256, 256),
+            cellType(rasterSource.cellType),
+            bandCount(rasterSource.bandCount)
           )
         }
       }
@@ -98,7 +98,7 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with BetterRaster
       actual: MultibandTileLayerRDD[SpatialKey],
       matchRasters: Boolean = false
     ): Unit = {
-      val joinedRDD = expected.filter{ case (_, t) => !t.band(0).isNoDataTile }.leftOuterJoin(actual)
+      val joinedRDD = expected.filter { case (_, t) => !t.band(0).isNoDataTile }.leftOuterJoin(actual)
 
       joinedRDD.collect().foreach { case (key, (expected, actualTile)) =>
         actualTile match {
@@ -117,10 +117,10 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with BetterRaster
 
             // withGeoTiffClue(key, layout, actual, expected, targetCRS) {
             withClue(s"$key:") {
-              expected.dimensions should be (actual.dimensions)
-              if(matchRasters) assertTilesEqual(expected, actual)
+              expected.dimensions should be(actual.dimensions)
+              if (matchRasters) assertTilesEqual(expected, actual)
             }
-            // }
+          // }
 
           case None =>
             throw new Exception(s"$key does not exist in the rasterSourceRDD")

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSummarySpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSummarySpec.scala
@@ -23,11 +23,11 @@ class RasterSummarySpec extends FunSpec with TestEnvironment with BetterRasterMa
 
       val sourceRDD: RDD[RasterSource] =
         sc.parallelize(files, files.length)
-          .map(uri => new GeoTiffRasterSource(uri): RasterSource)
+          .map(uri => GeoTiffRasterSource(uri): RasterSource)
           .cache()
 
       val metadata = RasterSummary.fromRDD(sourceRDD)
-      val rasterSource = new GeoTiffRasterSource(inputPath)
+      val rasterSource = GeoTiffRasterSource(inputPath)
 
       rasterSource.crs shouldBe metadata.crs
       rasterSource.extent shouldBe metadata.extent
@@ -46,7 +46,7 @@ class RasterSummarySpec extends FunSpec with TestEnvironment with BetterRasterMa
 
       val sourceRDD: RDD[RasterSource] =
         sc.parallelize(files, files.length)
-          .map(uri => new GeoTiffRasterSource(uri).reproject(targetCRS, method): RasterSource)
+          .map(uri => GeoTiffRasterSource(uri).reproject(targetCRS, method): RasterSource)
           .cache()
 
       val summary = RasterSummary.fromRDD(sourceRDD)
@@ -87,7 +87,7 @@ class RasterSummarySpec extends FunSpec with TestEnvironment with BetterRasterMa
     // read sources
     val sourceRDD: RDD[RasterSource] =
       sc.parallelize(files, files.length)
-        .map(uri => new GeoTiffRasterSource(uri).reproject(targetCRS, method): RasterSource)
+        .map(uri => GeoTiffRasterSource(uri).reproject(targetCRS, method): RasterSource)
         .cache()
 
     // collect raster summary


### PR DESCRIPTION
This new GT-GDAL version sets options to prevent SEGSEV failures.