### PR TITLE
Allow s3 client configuration for global object access

### DIFF
--- a/vlm/src/main/resources/reference.conf
+++ b/vlm/src/main/resources/reference.conf
@@ -1,17 +1,3 @@
-gdal {
-  options {
-    maxDatasetPoolSize: 1
-    vrtSharedSource: false
-  }
-  cache {
-    maximumSize: 100
-    enableDefaultRemovalListener: true
-    valuesType: Weak
-    enabled: true
-    withShutdownHook: true
-  }
-}
-
 vlm.geotiff.s3 {
   allowGlobalRead: false
 }

--- a/vlm/src/main/resources/reference.conf
+++ b/vlm/src/main/resources/reference.conf
@@ -1,0 +1,17 @@
+gdal {
+  options {
+    maxDatasetPoolSize: 1
+    vrtSharedSource: false
+  }
+  cache {
+    maximumSize: 100
+    enableDefaultRemovalListener: true
+    valuesType: Weak
+    enabled: true
+    withShutdownHook: true
+  }
+}
+
+vlm.geotiff.s3 {
+  allowGlobalRead: false
+}

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/Config.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/Config.scala
@@ -1,0 +1,8 @@
+package geotrellis.contrib.vlm
+
+import pureconfig._
+
+object Config {
+  case class S3Options(allowGlobalRead: Boolean)
+  val s3 = pureconfig.loadConfigOrThrow[S3Options]("vlm.geotiff.s3")
+}

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/package.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/package.scala
@@ -34,8 +34,8 @@ package object vlm {
 
     val rr =  javaURI.getScheme match {
       case null =>
-        FileRangeReader(Paths.get(javaURI.toString).toFile)      
-      
+        FileRangeReader(Paths.get(javaURI.toString).toFile)
+
       case "file" =>
         FileRangeReader(Paths.get(javaURI).toFile)
 
@@ -47,7 +47,16 @@ package object vlm {
 
       case "s3" =>
         val s3Uri = new AmazonS3URI(java.net.URLDecoder.decode(uri, "UTF-8"))
-        val s3Client = new AmazonS3Client(AmazonS3ClientBuilder.defaultClient())
+        val s3Client = if (Config.s3.allowGlobalRead) {
+          new AmazonS3Client(
+            AmazonS3ClientBuilder
+              .standard()
+              .withForceGlobalBucketAccessEnabled(true)
+              .build()
+          )
+        } else {
+          new AmazonS3Client(AmazonS3ClientBuilder.defaultClient())
+        }
         S3RangeReader(s3Uri.getBucket, s3Uri.getKey, s3Client)
 
       case scheme =>


### PR DESCRIPTION
Overview
-----

This PR creates a configuration key to allow global s3 bucket access. It's useful for client applications in which the location of imagery isn't controlled by the application, but by users of the application.

Testing
-----

I get instant console rot every time I try to open up a console, so I'm not sure what testing looks like

Related to #70 