### PR TITLE
Fix source overview selection in GeoTiffReprojectRasterSource

### DIFF
--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
@@ -40,7 +40,7 @@ case class GeoTiffRasterSource(uri: String) extends RasterSource {
   def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): GeoTiffReprojectRasterSource =
     GeoTiffReprojectRasterSource(uri, targetCRS, reprojectOptions, strategy)
 
-  def resample(resampleGrid: ResampleGrid, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
+  def resample(resampleGrid: ResampleGrid, method: ResampleMethod, strategy: OverviewStrategy): GeoTiffResampleRasterSource =
     GeoTiffResampleRasterSource(uri, resampleGrid, method, strategy)
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
@@ -52,7 +52,7 @@ case class GeoTiffReprojectRasterSource(
   lazy val resolutions: List[RasterExtent] =
     rasterExtent :: tiff.overviews.map(ovr => ReprojectRasterExtent(ovr.rasterExtent, transform))
 
-  @transient protected lazy val closestTiffOverview: GeoTiff[MultibandTile] =
+  @transient private[vlm] lazy val closestTiffOverview: GeoTiff[MultibandTile] =
     tiff.getClosestOverview(rasterExtent.cellSize, strategy)
 
   def bandCount: Int = tiff.bandCount

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSourceSpec.scala
@@ -95,22 +95,31 @@ class GeoTiffReprojectRasterSourceSpec extends FunSpec with TestEnvironment with
       // known good start, CellSize(10, 10) is the base resolution of source
       baseReproject.closestTiffOverview.cellSize shouldBe CellSize(10, 10)
 
+      info(s"lcc resolutions: ${rasterSource.resolutions.map(_.cellSize)}")
       val twiceFuzzyLayout = {
         val CellSize(width, height) = baseReproject.cellSize
-        LayoutDefinition(RasterExtent(LatLng.worldExtent, CellSize(width*2, height*2)), tileSize = 256)
+        LayoutDefinition(RasterExtent(LatLng.worldExtent, CellSize(width*2.1, height*2.1)), tileSize = 256)
       }
 
       val twiceFuzzySource = rasterSource.reprojectToGrid(LatLng, twiceFuzzyLayout).asInstanceOf[GeoTiffReprojectRasterSource]
       twiceFuzzySource.closestTiffOverview.cellSize shouldBe CellSize(20,20)
 
-
       val thriceFuzzyLayout = {
         val CellSize(width, height) = baseReproject.cellSize
-        LayoutDefinition(RasterExtent(LatLng.worldExtent, CellSize(width*3, height*3)), tileSize = 256)
+        LayoutDefinition(RasterExtent(LatLng.worldExtent, CellSize(width*3.5, height*3.5)), tileSize = 256)
       }
 
       val thriceFuzzySource = rasterSource.reprojectToGrid(LatLng, thriceFuzzyLayout).asInstanceOf[GeoTiffReprojectRasterSource]
-      thriceFuzzySource.closestTiffOverview.cellSize shouldBe CellSize(30,30)
+      thriceFuzzySource.closestTiffOverview.cellSize shouldBe CellSize(20,20)
+
+      val quatroFuzzyLayout = {
+        val CellSize(width, height) = baseReproject.cellSize
+        LayoutDefinition(RasterExtent(LatLng.worldExtent, CellSize(width*4.1, height*4.1)), tileSize = 256)
+      }
+
+      val quatroTimesFuzzySource = rasterSource.reprojectToGrid(LatLng, quatroFuzzyLayout).asInstanceOf[GeoTiffReprojectRasterSource]
+      quatroTimesFuzzySource.closestTiffOverview.cellSize shouldBe CellSize(40.0,39.94082840236686)
+
     }
   }
 }


### PR DESCRIPTION
Original code would use the `cellSize` in target CRS to select overview resolution in source CRS.
Previous unit tests did not catch it because they were between `lcc` and `merc` which both have units in meters, so the results where within margin of error.

Closes: https://github.com/geotrellis/geotrellis-contrib/issues/73