### PR TITLE
Fix PaddedTile foreach and map visitors

### DIFF
--- a/vlm/src/main/scala/geotrellis/contrib/vlm/PaddedTile.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/PaddedTile.scala
@@ -77,13 +77,43 @@ case class PaddedTile(chunk: Tile, colOffset: Int, rowOffset: Int, cols: Int, ro
   }
 
   def foreach(f: Int => Unit): Unit = {
-    chunk.foreach(f)
-    cfor(0)(_ < (this.size - chunk.size), _ + 1) { i => f(NODATA) }
+    cfor(0)(_ < rows, _ + 1) { row =>
+      if (row < rowOffset || row > (rowOffset + rows - 1)) {
+        cfor(0)(_ < cols, _ + 1) { _ =>
+          f(NODATA)
+        }
+      } else {
+        cfor(0)(_ < colOffset, _ + 1) { _ =>
+          f(NODATA)
+        }
+        cfor(0)(_ < chunk.cols, _ + 1) { col =>
+          f(chunk.get(col, row - rowOffset))
+        }
+        cfor(colOffset + chunk.cols)(_ < cols, _ + 1) { _ =>
+          f(NODATA)
+        }
+      }
+    }
   }
 
   def foreachDouble(f: Double => Unit): Unit = {
-    chunk.foreachDouble(f)
-    cfor(0)(_ < (this.size - chunk.size), _ + 1) { i => f(Double.NaN) }
+    cfor(0)(_ < rows, _ + 1) { row =>
+      if (row < rowOffset || row > (rowOffset + rows - 1)) {
+        cfor(0)(_ < cols, _ + 1) { _ =>
+          f(Double.NaN)
+        }
+      } else {
+        cfor(0)(_ < colOffset, _ + 1) { _ =>
+          f(Double.NaN)
+        }
+        cfor(0)(_ < chunk.cols, _ + 1) { col =>
+          f(chunk.getDouble(col, row - rowOffset))
+        }
+        cfor(colOffset + chunk.cols)(_ < cols, _ + 1) { _ =>
+          f(Double.NaN)
+        }
+      }
+    }
   }
 
   def mutable(): MutableArrayTile =
@@ -172,8 +202,45 @@ case class PaddedTile(chunk: Tile, colOffset: Int, rowOffset: Int, cols: Int, ro
     tile
   }
 
-  def foreachIntVisitor(visitor: IntTileVisitor): Unit = chunk.foreachIntVisitor(visitor)
-  def foreachDoubleVisitor(visitor: DoubleTileVisitor): Unit = chunk.foreachDoubleVisitor(visitor)
+  def foreachIntVisitor(visitor: IntTileVisitor): Unit = {
+    cfor(0)(_ < rows, _ + 1) { row =>
+      if (row < rowOffset || row > (rowOffset + rows - 1)) {
+        cfor(0)(_ < cols, _ + 1) { col =>
+          visitor(col, row, NODATA)
+        }
+      } else {
+        cfor(0)(_ < colOffset, _ + 1) { col =>
+          visitor(col, row, NODATA)
+        }
+        cfor(0)(_ < chunk.cols, _ + 1) { col =>
+          visitor(col + colOffset, row, chunk.get(col, row - rowOffset))
+        }
+        cfor(colOffset + chunk.cols)(_ < cols, _ + 1) { col =>
+          visitor(col, row, NODATA)
+        }
+      }
+    }
+  }
+
+  def foreachDoubleVisitor(visitor: DoubleTileVisitor): Unit = {
+    cfor(0)(_ < rows, _ + 1) { row =>
+      if (row < rowOffset || row > (rowOffset + rows - 1)) {
+        cfor(0)(_ < cols, _ + 1) { col =>
+          visitor(col, row, Double.NaN)
+        }
+      } else {
+        cfor(0)(_ < colOffset, _ + 1) { col =>
+          visitor(col, row, Double.NaN)
+        }
+        cfor(0)(_ < chunk.cols, _ + 1) { col =>
+          visitor(col + colOffset, row, chunk.getDouble(col, row - rowOffset))
+        }
+        cfor(colOffset + chunk.cols)(_ < cols, _ + 1) { col =>
+          visitor(col, row, Double.NaN)
+        }
+      }
+    }
+  }
 
   def mapIntMapper(mapper: IntTileMapper): Tile = {
     val tile = ArrayTile.alloc(cellType, cols, rows)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/PaddedTile.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/PaddedTile.scala
@@ -245,7 +245,7 @@ case class PaddedTile(chunk: Tile, colOffset: Int, rowOffset: Int, cols: Int, ro
   def mapIntMapper(mapper: IntTileMapper): Tile = {
     val tile = ArrayTile.alloc(cellType, cols, rows)
     chunk.foreach { (col, row, z) =>
-      tile.set(col, row, mapper(col, row, z))
+      tile.set(colOffset + col, rowOffset + row, mapper(col, row, z))
     }
 
     tile
@@ -254,7 +254,7 @@ case class PaddedTile(chunk: Tile, colOffset: Int, rowOffset: Int, cols: Int, ro
   def mapDoubleMapper(mapper: DoubleTileMapper): Tile = {
     val tile = ArrayTile.alloc(cellType, cols, rows)
     chunk.foreachDouble { (col, row, z) =>
-      tile.setDouble(col, row, mapper(col, row, z))
+      tile.setDouble(colOffset + col, rowOffset + row, mapper(col, row, z))
     }
 
     tile

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/PaddedTileSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/PaddedTileSpec.scala
@@ -1,0 +1,78 @@
+package geotrellis.contrib.vlm
+
+import geotrellis.raster._
+import geotrellis.raster.testkit.RasterMatchers
+import org.scalatest._
+import spire.syntax.cfor._
+
+class PaddedTileSpec extends FunSpec with Matchers with BetterRasterMatchers with RasterMatchers {
+  val padded = PaddedTile(
+    chunk = IntArrayTile.fill(1, cols = 8, rows = 8),
+    colOffset = 8, rowOffset = 8, cols = 16, rows = 16)
+
+  val expected = {
+    val tile = IntArrayTile.empty(16, 16)
+    cfor(8)(_ < 16, _ + 1) { col =>
+      cfor(8)(_ < 16, _ + 1) { row =>
+        tile.set(col, row, 1)
+      }
+    }
+    tile
+  }
+
+  it("foreach should iterate correct cell count") {
+    var noDataCount = 0
+    var dataCount = 0
+    padded.foreach { z => if (isNoData(z)) noDataCount +=1 else dataCount += 1}
+
+    dataCount shouldBe 8*8
+    (dataCount + noDataCount) should be (16 * 16)
+  }
+
+  it("foreachDouble should iterate correct cell count") {
+    var noDataCount = 0
+    var dataCount = 0
+    padded.foreachDouble { z => if (isNoData(z)) noDataCount +=1 else dataCount += 1}
+
+    dataCount shouldBe 8*8
+    (dataCount + noDataCount) should be (16 * 16)
+  }
+
+  it("should implement col,row,value visitor for Int") {
+    padded.foreach((col, row, z) =>
+      withClue(s"col = $col, row = $row") {
+        z shouldBe expected.get(col, row)
+      }
+    )
+  }
+
+  it("should implement col,row,value visitor for Double") {
+    padded.foreachDouble((col, row, z) =>
+      withClue(s"col = $col, row = $row") {
+        val x = expected.getDouble(col, row)
+        // (Double.NaN == Double.NaN) == false
+        if (isData(z) || isData(x)) z shouldBe x
+      }
+    )
+  }
+
+  it("should implement row-major foreach") {
+    val copy = IntArrayTile.empty(16, 16)
+    var i = 0
+    padded.foreach{ z =>
+      copy.update(i, z)
+      i += 1
+    }
+    copy shouldBe expected
+  }
+
+  it("should implement row-major foreachDouble") {
+    val copy = IntArrayTile.empty(16, 16)
+    var i = 0
+    padded.foreachDouble{ z =>
+      copy.updateDouble(i, z)
+      i += 1
+    }
+    copy shouldBe expected
+  }
+}


### PR DESCRIPTION
- `foreach` and `map` visitors were getting col/row values relative to chunk rather than padded tile itself
- Imposed row-major traversal order in `foreach(z)` and `foreachDouble(x)` methods

These were discovered via a bug that shifted the data region to upper left corner when a tile was being rendered.