### PR TITLE
GDALBaseRasterSource does not pad to requested bounds

### DIFF
--- a/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALBaseRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALBaseRasterSource.scala
@@ -92,31 +92,14 @@ trait GDALBaseRasterSource extends RasterSource {
   }
 
   override def readBounds(bounds: Traversable[GridBounds], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
-    val tuples =
-      bounds.map { gb =>
-        val re = rasterExtent.rasterExtentFor(gb)
-        val boundsClamped = rasterExtent.gridBoundsFor(re.extent, clamp = true)
-        (gb, boundsClamped, re)
+    bounds
+      .toIterator
+      .flatMap { gb => gridBounds.intersection(gb) }
+      .map { gb =>
+        val tile = reader.read(gb, bands = bands)
+        val extent = rasterExtent.extentFor(gb)
+        Raster(tile, extent)
       }
-
-    tuples.map { case (gb, gbc, re) =>
-      val initialTile = reader.read(gb, bands = bands)
-
-      val (gridBounds, tile) =
-        if (initialTile.cols != re.cols || initialTile.rows != re.rows) {
-          val updatedTiles = initialTile.bands.map { band =>
-            // TODO: it can't be larger than the source is, fix it
-            val protoTile = band.prototype(re.cols, re.rows)
-
-            protoTile.update(gb.colMin - gbc.colMin, gb.rowMin - gbc.rowMin, band)
-            protoTile
-          }
-
-          (gb, MultibandTile(updatedTiles))
-        } else (gbc, initialTile)
-
-      Raster(tile, rasterExtent.extentFor(gridBounds))
-    }.toIterator
   }
 
   def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource =


### PR DESCRIPTION
This is the consistent behavior with GeoTiffRaster source. If padded area is expected `PaddedTile` must be used.

Small fix that improves consistency and performance.