### PR TITLE
Band Multiplexing

### DIFF
--- a/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSourceRDD.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSourceRDD.scala
@@ -58,7 +58,7 @@ object RasterSourceRDD {
     val layerMetadata =
       TileLayerMetadata[SpatialKey](cellType, layout, combinedExtents, crs, layerKeyBounds)
 
-    lazy val noDataTile = ArrayTile.alloc(cellType, layout.tileCols, layout.tileRows).fill(NODATA)
+    lazy val noDataTile = ArrayTile.alloc(cellType, layout.tileCols, layout.tileRows).fill(NODATA).interpretAs(cellType)
 
     val maxIndex = readingSources.map { _.targetBand }.max
     val targetIndexes: Seq[Int] = 0 to maxIndex

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSourceRDD.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSourceRDD.scala
@@ -32,6 +32,84 @@ import scala.reflect.ClassTag
 object RasterSourceRDD {
   final val PARTITION_BYTES: Long = 128l * 1024 * 1024
 
+  def read(
+    readingSources: Seq[ReadingSource],
+    layout: LayoutDefinition,
+    partitionBytes: Long = PARTITION_BYTES
+  )(implicit sc: SparkContext): MultibandTileLayerRDD[SpatialKey] = {
+    val cellTypes = readingSources.map { _.source.cellType }.toSet
+    require(cellTypes.size == 1, s"All RasterSources must have the same CellType, but multiple ones were found: $cellTypes")
+
+    val projections = readingSources.map { _.source.crs }.toSet
+    require(
+      projections.size == 1,
+      s"All RasterSources must be in the same projection, but multiple ones were found: $projections"
+    )
+
+    val cellType = cellTypes.head
+    val crs = projections.head
+
+    val mapTransform = layout.mapTransform
+    val combinedExtents = readingSources.map { _.source.extent }.reduce { _ combine _ }
+
+    val layerKeyBounds = KeyBounds(mapTransform(combinedExtents))
+    val tileSize = layout.tileCols * layout.tileRows * cellType.bytes
+
+    val layerMetadata =
+      TileLayerMetadata[SpatialKey](cellType, layout, combinedExtents, crs, layerKeyBounds)
+
+    lazy val noDataTile = ArrayTile.alloc(cellType, layout.tileCols, layout.tileRows).fill(NODATA)
+
+    val maxIndex = readingSources.map { _.targetBand }.max
+    val targetIndexes: Seq[Int] = 0 to maxIndex
+
+    val sourcesRDD: RDD[(SpatialKey, (Int, Option[MultibandTile]))] =
+      sc.parallelize(readingSources).flatMap { source =>
+        val layoutSource = new LayoutTileSource(source.source, layout)
+
+        val sourceBand = source.sourceBand
+        val targetBand = source.targetBand
+        val keys = layoutSource.keys
+
+        partition(keys, partitionBytes)( _ => tileSize).flatMap { _.map { key =>
+          (key, (targetBand, layoutSource.read(key, Seq(sourceBand))))
+          }
+        }
+      }
+
+    sourcesRDD.persist()
+
+    val repartitioned = {
+      val count = sourcesRDD.count.toInt
+      if (count > sourcesRDD.partitions.size)
+        sourcesRDD.repartition(count)
+      else
+        sourcesRDD
+    }
+
+    val groupedSourcesRDD: RDD[(SpatialKey, Iterable[(Int, Option[MultibandTile])])] =
+      repartitioned.groupByKey()
+
+    val result: RDD[(SpatialKey, MultibandTile)] =
+    groupedSourcesRDD.mapValues { iter =>
+      val mappedBands: Map[Int, Option[MultibandTile]] = iter.toSeq.sortBy { _._1 }.toMap
+
+      val tiles: Seq[Tile] =
+        targetIndexes.map { index =>
+          mappedBands.get(index).getOrElse(None) match {
+            case Some(multibandTile) => multibandTile.band(0)
+            case None => noDataTile
+          }
+        }
+
+      MultibandTile(tiles)
+    }
+
+    sourcesRDD.unpersist()
+
+    ContextRDD(result, layerMetadata)
+  }
+
   def apply(
     sources: Seq[RasterSource],
     layout: LayoutDefinition,
@@ -65,7 +143,7 @@ object RasterSourceRDD {
           extent.intersection(source.extent) match {
             case Some(intersection) =>
               layout.mapTransform.keysForGeometry(intersection.toPolygon)
-            case None => 
+            case None =>
               Seq.empty[SpatialKey]
           }
         val tileSize = layout.tileCols * layout.tileRows * cellType.bytes

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/ReadingSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/ReadingSource.scala
@@ -1,0 +1,8 @@
+package geotrellis.contrib.vlm
+
+
+case class ReadingSource(
+  source: RasterSource,
+  sourceBand: Int,
+  targetBand: Int
+) extends Serializable

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/ReadingSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/ReadingSource.scala
@@ -5,3 +5,11 @@ case class ReadingSource(
   source: RasterSource,
   sourceToTargetBand: Map[Int, Int]
 ) extends Serializable
+
+object ReadingSource {
+  def apply(source: RasterSource, sourceBand: Int, targetBand: Int): ReadingSource =
+    ReadingSource(source, Map(sourceBand -> targetBand))
+
+  def apply(source: RasterSource, targetBand: Int): ReadingSource =
+    apply(source, 0, targetBand)
+}

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/ReadingSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/ReadingSource.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package geotrellis.contrib.vlm
 
 

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/ReadingSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/ReadingSource.scala
@@ -3,6 +3,5 @@ package geotrellis.contrib.vlm
 
 case class ReadingSource(
   source: RasterSource,
-  sourceBand: Int,
-  targetBand: Int
+  sourceToTargetBand: Map[Int, Int]
 ) extends Serializable

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSourceRDDSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSourceRDDSpec.scala
@@ -50,7 +50,6 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with BetterRaster
 
   val reprojectedSource = rasterSource.reprojectToGrid(targetCRS, layout)
 
-  /*
   describe("reading in GeoTiffs as RDDs") {
     it("should have the right number of tiles") {
       val expectedKeys =
@@ -271,7 +270,6 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with BetterRaster
       }
     }
   }
-  */
 
   describe("RasterSourceRDD.read") {
     val floatingScheme = FloatingLayoutScheme(500, 270)

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSourceRDDSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSourceRDDSpec.scala
@@ -278,7 +278,6 @@ class RasterSourceRDDSpec extends FunSpec with TestEnvironment with BetterRaster
     val cellType = rasterSource.cellType
 
     val multibandTilePath = s"${new File("").getAbsolutePath()}/src/test/resources/img/aspect-tiled-0-1-2.tif"
-    val multibandTile = MultibandGeoTiff(multibandTilePath, streaming = false).tile
 
     val noDataTile = ArrayTile.alloc(cellType, rasterSource.cols, rasterSource.rows).fill(NODATA).interpretAs(cellType)
 


### PR DESCRIPTION
This PR adds the `read` method to `RasterSourceRDD`. This method will take in any number of `ReadingSource`s and convert them into a single `MultibandTile` based on the order of the bands given.