### PR TITLE
Add resampling and reprojecting to GeotrellisRasterSource

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,8 +17,8 @@
 import sbt._
 
 object Version {
-  val geotrellis     = "3.0.0-SNAPSHOT"
-  val geotrellisGdal = "0.17.5"
+  val geotrellis     = "2.2.0"
+  val geotrellisGdal = "0.17.8"
   val scala          = "2.11.12"
   val crossScala     = Seq(scala, "2.12.8")
   val hadoop         = "2.8.0"

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisRasterSource.scala
@@ -147,6 +147,14 @@ object GeotrellisRasterSource {
     }
   }
 
+  def readIntersecting(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[SpatialKey], extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
+    val tiles = readTiles(reader, layerId, extent, bands)
+    if (tiles.isEmpty)
+      None
+    else
+      Some(tiles.stitch())
+  }
+
   def read(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[SpatialKey], extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val tiles = readTiles(reader, layerId, extent, bands)
     if (tiles.isEmpty)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
@@ -82,7 +82,7 @@ case class GeotrellisReprojectRasterSource(
       _ <- this.extent.intersection(extent)
       targetRasterExtent = rasterExtent.createAlignedRasterExtent(extent)
       sourceExtent = targetRasterExtent.extent.reprojectAsPolygon(backTransform, 0.001).envelope
-      raster <- GeotrellisRasterSource.read(reader, layerId, metadata, sourceExtent, bands)
+      raster <- GeotrellisRasterSource.readIntersecting(reader, layerId, metadata, sourceExtent, bands)
     } yield {
       raster.reproject(targetRasterExtent, transform, backTransform, reprojectOptions)
     }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
@@ -70,7 +70,7 @@ case class GeotrellisReprojectRasterSource(
       || reprojectOptions.targetCellSize.isDefined)
     {
       // we're asked to match specific target resolution, estimate what resolution we need in source to sample it
-      val estimatedSource = ReprojectRasterExtent(rasterExtent, backTransform)
+      val estimatedSource = ReprojectRasterExtent(rasterExtent, backTransform, reprojectOptions)
       GeotrellisRasterSource.getClosestLayer(resolutions, layerIds, baseLayerId, estimatedSource.cellSize, strategy)
     } else {
       GeotrellisRasterSource.getClosestLayer(resolutions, layerIds, baseLayerId, baseRasterExtent.cellSize, strategy)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.contrib.vlm.avro
+
+import geotrellis.contrib.vlm._
+import geotrellis.vector._
+import geotrellis.raster._
+import geotrellis.raster.reproject._
+import geotrellis.raster.resample._
+import geotrellis.proj4._
+import geotrellis.raster.io.geotiff.{AutoHigherResolution, GeoTiff, GeoTiffMultibandTile, MultibandGeoTiff, OverviewStrategy}
+import geotrellis.raster.io.geotiff.reader.GeoTiffReader
+import geotrellis.spark.{LayerId, Metadata, SpatialKey, TileLayerMetadata}
+import geotrellis.spark.io._
+
+case class GeotrellisReprojectRasterSource(
+  uri: String,
+  baseLayerId: LayerId,
+  bandCount: Int,
+  crs: CRS,
+  reprojectOptions: Reproject.Options = Reproject.Options.DEFAULT,
+  strategy: OverviewStrategy = AutoHigherResolution
+) extends RasterSource { self =>
+  lazy val reader = CollectionLayerReader(uri)
+
+  lazy val metadata = reader.attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](layerId)
+
+  def cellType: CellType = metadata.cellType
+  def resampleMethod: Option[ResampleMethod] = Some(reprojectOptions.method)
+
+  protected lazy val baseCRS: CRS = baseMetadata.crs
+  protected lazy val baseMetadata = reader.attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](baseLayerId)
+  protected lazy val baseRasterExtent: RasterExtent =
+    baseMetadata.layout.createAlignedGridExtent(baseMetadata.extent).toRasterExtent()
+
+  protected lazy val transform = Transform(baseCRS, crs)
+  protected lazy val backTransform = Transform(crs, baseCRS)
+
+  protected lazy val layerName = baseLayerId.name
+  protected lazy val layerIds: Seq[LayerId] = GeotrellisRasterSource.getLayerIdsByName(reader, layerName)
+
+  override lazy val rasterExtent: RasterExtent = reprojectOptions.targetRasterExtent match {
+    case Some(targetRasterExtent) =>
+      targetRasterExtent
+    case None =>
+      ReprojectRasterExtent(baseRasterExtent, transform, reprojectOptions)
+  }
+
+  lazy val resolutions: List[RasterExtent] =
+    GeotrellisRasterSource.getResolutions(reader, layerName).map(resolution =>
+      ReprojectRasterExtent(resolution, transform))
+
+  @transient private[vlm] lazy val layerId: LayerId = {
+    if (reprojectOptions.targetRasterExtent.isDefined
+      || reprojectOptions.parentGridExtent.isDefined
+      || reprojectOptions.targetCellSize.isDefined)
+    {
+      // we're asked to match specific target resolution, estimate what resolution we need in source to sample it
+      val estimatedSource = ReprojectRasterExtent(rasterExtent, backTransform)
+      GeotrellisRasterSource.getClosestLayer(resolutions, layerIds, baseLayerId, estimatedSource.cellSize, strategy)
+    } else {
+      GeotrellisRasterSource.getClosestLayer(resolutions, layerIds, baseLayerId, baseRasterExtent.cellSize, strategy)
+    }
+  }
+
+  def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] =
+    GeotrellisRasterSource.read(reader, layerId, metadata, extent, bands)
+      .map { raster =>
+        val targetRasterExtent = rasterExtent.createAlignedRasterExtent(extent)
+        raster.reproject(targetRasterExtent, transform, backTransform, reprojectOptions)
+      }
+
+  def read(bounds: GridBounds, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
+    val extent: Extent = metadata.extentFor(bounds)
+    read(extent, bands)
+  }
+
+  override def readExtents(extents: Traversable[Extent], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
+    extents.toIterator.flatMap(extent => read(extent, bands))
+
+  override def readBounds(bounds: Traversable[GridBounds], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
+    bounds.toIterator.flatMap(bounds => read(bounds, bands))
+
+  def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource =
+    GeotrellisReprojectRasterSource(uri, baseLayerId, bandCount, crs, reprojectOptions, strategy)
+
+  def resample(resampleGrid: ResampleGrid, method: ResampleMethod, strategy: OverviewStrategy): RasterSource = {
+    val resampledReprojectOptions = reprojectOptions.copy(method = method, targetRasterExtent = Some(resampleGrid(self.rasterExtent)))
+    GeotrellisReprojectRasterSource(uri, baseLayerId, bandCount, crs, resampledReprojectOptions, strategy)
+  }
+}

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisResampleRasterSource.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.contrib.vlm.avro
+
+import geotrellis.contrib.vlm._
+import geotrellis.contrib.vlm.avro._
+import geotrellis.contrib.vlm.geotiff._
+import geotrellis.vector._
+import geotrellis.proj4._
+import geotrellis.raster._
+import geotrellis.raster.reproject.{Reproject, ReprojectRasterExtent}
+import geotrellis.raster.resample.{NearestNeighbor, ResampleMethod}
+import geotrellis.raster.io.geotiff.{Auto, AutoHigherResolution, Base, OverviewStrategy}
+import geotrellis.spark.{LayerId, Metadata, SpatialKey, TileLayerMetadata}
+import geotrellis.spark.io._
+
+case class GeotrellisResampleRasterSource(
+  uri: String,
+  layerName: String,
+  bandCount: Int,
+  baseRasterExtent: RasterExtent,
+  resampleGrid: ResampleGrid,
+  method: ResampleMethod = NearestNeighbor,
+  strategy: OverviewStrategy = AutoHigherResolution
+) extends RasterSource { self =>
+  lazy val reader = CollectionLayerReader(uri)
+
+  @transient protected lazy val layerId: LayerId =
+    getClosestLayer(rasterExtent.cellSize, strategy)
+
+  lazy val metadata = reader.attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](layerId)
+
+  def crs: CRS = metadata.crs
+  def cellType: CellType = metadata.cellType
+  def resampleMethod: Option[ResampleMethod] = Some(method)
+
+  lazy val rasterExtent: RasterExtent = resampleGrid(baseRasterExtent)
+  lazy val resolutions: List[RasterExtent] = GeotrellisRasterSource.getResolutions(reader, layerName)
+  lazy val layerIds: Seq[LayerId] = GeotrellisRasterSource.getLayerIdsByName(reader, layerName)
+  lazy val resolutionLayerIds: Map[RasterExtent, LayerId] = (resolutions zip layerIds).toMap
+
+  def getClosestLayer(cellSize: CellSize, strategy: OverviewStrategy = AutoHigherResolution): LayerId = {
+    val closestResolution = strategy match {
+      case AutoHigherResolution =>
+        resolutions
+          .map { v => (cellSize.resolution - v.cellSize.resolution) -> v }
+          .filter(_._1 >= 0)
+          .sortBy(_._1)
+          .map(_._2)
+          .headOption
+          .getOrElse(rasterExtent)
+      case Auto(n) =>
+        resolutions
+          .sortBy(v => math.abs(cellSize.resolution - v.cellSize.resolution))
+          .lift(n)
+          .getOrElse(rasterExtent) // n can be out of bounds,
+      // makes only overview lookup as overview position is important
+      case Base => rasterExtent
+    }
+    resolutionLayerIds.get(closestResolution) match {
+      case Some(closestLayerId) =>
+        closestLayerId
+      case None =>
+        throw new Exception("Could not find closest layer")
+    }
+  }
+
+  def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
+    GeotrellisRasterSource.read(reader, layerId, metadata, extent, bands)
+      .map { raster =>
+        val targetRasterExtent = rasterExtent.createAlignedRasterExtent(extent)
+        raster.resample(targetRasterExtent, method)
+      }
+  }
+
+  def read(bounds: GridBounds, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
+    val extent: Extent = metadata.extentFor(bounds)
+    read(extent, bands)
+  }
+
+  def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): GeoTiffReprojectRasterSource =
+    ???
+
+  def resample(resampleGrid: ResampleGrid, method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
+    GeotrellisResampleRasterSource(uri, layerName, bandCount, baseRasterExtent, resampleGrid, method, strategy)
+
+  override def readExtents(extents: Traversable[Extent], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
+    extents.toIterator.flatMap(extent => read(extent, bands))
+
+  override def readBounds(bounds: Traversable[GridBounds], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
+    bounds.toIterator.flatMap(bounds => read(bounds, bands))
+}

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisResampleRasterSource.scala
@@ -57,7 +57,7 @@ case class GeotrellisResampleRasterSource(
   lazy val layerIds: Seq[LayerId] = GeotrellisRasterSource.getLayerIdsByName(reader, layerName)
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] =
-    GeotrellisRasterSource.read(reader, layerId, metadata, extent, bands)
+    GeotrellisRasterSource.readIntersecting(reader, layerId, metadata, extent, bands)
       .map { raster =>
         val targetRasterExtent = rasterExtent.createAlignedRasterExtent(extent)
         raster.resample(targetRasterExtent, method)


### PR DESCRIPTION
# Overview

Add resampling and reprojecting to `GeotrellisRasterSource` via the new `GeotrellisResampleRasterSource` and `GeotrellisReprojectRasterSource` classes.

# Notes

The common functionality between the three classes was broken out into the `GeotrellisRasterSource` object in an effort to avoid duplication and improve testability.

 The test for reprojection is currently not passing. I think it's close but it might require some love from @echeipesh to push it over the finish line. See: https://github.com/geotrellis/geotrellis-contrib/blob/9fba2db98f15072707c4bdc1f7eeec99e11277c0/vlm/src/test/scala/geotrellis/contrib/vlm/avro/GeotrellisRasterSourceSpec.scala#L178