### PR TITLE
RasterSource uses GridExtent instead of RasterExtent

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ lazy val vlm = project
     ),
     Test / fork := true,
     Test / parallelExecution := false,
-    Test / testOptions += Tests.Argument("-oDF"),
+    Test / testOptions += Tests.Argument("-oD"),
     javaOptions ++= Seq("-Djava.library.path=/usr/local/lib")
   )
   .settings(

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/RasterRegion.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/RasterRegion.scala
@@ -32,20 +32,16 @@ case class RasterRegion(
 ) extends CellGrid with Serializable {
   @transient lazy val raster: Option[Raster[MultibandTile]] =
     for {
-      raster <- source.read(rasterExtent.extent)
+      raster <- source.read(extent)
     } yield {
       if (raster.tile.cols == rasterExtent.cols && raster.tile.rows == rasterExtent.rows)
         raster
-      else { // we have a raster that's smaller or larger than desired
+      else { // we have a raster that's smaller than desired
         val gb = rasterExtent.gridBoundsFor(raster.extent)
-        val sgb = raster
-          .gridBounds
-          .intersection(GridBounds(gb.colMin, gb.rowMin, cols - 1, rows - 1))
-          .getOrElse(GridBounds(0, 0, cols - 1, rows - 1))
 
         val tile = raster.tile.mapBands { (_, band) =>
-          PaddedTile(band.crop(sgb), gb.colMin, gb.rowMin, cols, rows)
-      }
+          PaddedTile(band, gb.colMin, gb.rowMin, cols, rows)
+        }
         Raster(tile, rasterExtent.extent)
       }
     }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/RasterRegion.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/RasterRegion.scala
@@ -36,10 +36,15 @@ case class RasterRegion(
     } yield {
       if (raster.tile.cols == rasterExtent.cols && raster.tile.rows == rasterExtent.rows)
         raster
-      else { // we have a raster thats smaller than desired
+      else { // we have a raster that's smaller or larger than desired
         val gb = rasterExtent.gridBoundsFor(raster.extent)
+        val sgb = raster
+          .gridBounds
+          .intersection(GridBounds(gb.colMin, gb.rowMin, cols - 1, rows - 1))
+          .getOrElse(GridBounds(0, 0, cols - 1, rows - 1))
+
         val tile = raster.tile.mapBands { (_, band) =>
-          PaddedTile(band, gb.colMin, gb.rowMin, cols, rows)
+          PaddedTile(band.crop(sgb), gb.colMin, gb.rowMin, cols, rows)
       }
         Raster(tile, rasterExtent.extent)
       }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
@@ -47,6 +47,8 @@ trait RasterSource extends CellGrid with AutoCloseable with Serializable {
   def uri: String
   def crs: CRS
   def bandCount: Int
+  def cols: Int = (gridExtent.extent.width / gridExtent.cellwidth).toInt
+  def rows: Int = (gridExtent.extent.height / gridExtent.cellheight).toInt
 
   def cellType: CellType
 
@@ -54,9 +56,9 @@ trait RasterSource extends CellGrid with AutoCloseable with Serializable {
     *
     * Note: some re-sampling of underlying raster data may be required to produce this cell size.
     */
-  def cellSize: CellSize = rasterExtent.cellSize
+  def cellSize: CellSize = gridExtent.cellSize
 
-  def rasterExtent: RasterExtent
+  def gridExtent: GridExtent
 
   /** All available resolutions for this raster source
     *
@@ -70,18 +72,15 @@ trait RasterSource extends CellGrid with AutoCloseable with Serializable {
     *
     * __Note__: It is expected but not guaranteed that the extent each [[RasterExtent]] in this list will be the same.
     */
-  def resolutions: List[RasterExtent]
+  def resolutions: List[GridExtent]
 
-  def extent: Extent = rasterExtent.extent
+  def extent: Extent = gridExtent.extent
 
-  /** Raster pixel column count */
-  def cols: Int = rasterExtent.cols
-
-  /** Raster pixel row count */
-  def rows: Int = rasterExtent.rows
-
-  /** Raster pixel bounds */
-  def bounds: GridBounds = GridBounds(0, 0, cols - 1, rows - 1)
+//  /** Raster pixel column count */
+//  def cols: Int = gridExtent.cols
+//
+//  /** Raster pixel row count */
+//  def rows: Int = gridExtent.rows
 
   /** Reproject to different CRS with explicit sampling reprojectOptions.
     * @see [[geotrellis.raster.reproject.Reproject]]

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSummary.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSummary.scala
@@ -87,7 +87,7 @@ case class RasterSummary(
       cellType = cellType,
       cellSize = re.cellSize,
       extent   = re.extent,
-      cells    = re.size,
+      cells    = (re.extent.width / re.cellwidth).toLong * (re.extent.height / re.cellheight).toLong,
       count    = count
     )
   }
@@ -131,4 +131,3 @@ object RasterSummary {
     all.head
   }
 }
-

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/ResampleGrid.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/ResampleGrid.scala
@@ -16,24 +16,54 @@
 
 package geotrellis.contrib.vlm
 
-import geotrellis.raster.{RasterExtent, GridExtent}
+import geotrellis.vector.Extent
+import geotrellis.raster.{RasterExtent, GridExtent, CellSize}
+import geotrellis.raster.reproject.Reproject
+import geotrellis.raster.resample.ResampleMethod
 
 sealed trait ResampleGrid {
   // this is a by name parameter, as we don't need to call the source in all ResampleGrid types
-  def apply(source: => RasterExtent): RasterExtent
+  def apply(source: => GridExtent): GridExtent
+
+  /** This is a temporary adapter
+    * @param extent Extent of raster footprint after reprojection.
+    */
+  def reprojectOptions(extent: => Extent,  method: ResampleMethod): Reproject.Options
 }
 
+/** Determines target cell size through pixel column and row dimenions
+  * Target `Extent` is determined from the source `Extent`.
+  */
 case class Dimensions(cols: Int, rows: Int) extends ResampleGrid {
-  def apply(source: => RasterExtent): RasterExtent =
-    RasterExtent(source.extent, cols, rows)
+  def apply(source: => GridExtent): GridExtent =
+    RasterExtent(source.extent, cols, rows): GridExtent
+
+  def reprojectOptions(extent: => Extent,  method: ResampleMethod): Reproject.Options = {
+    val cs = CellSize(width = extent.width / cols,  height = extent.height / rows)
+    Reproject.Options(method = method, targetCellSize = Some(cs))
+  }
 }
 
+/** Align target pixel grid and cell size to given grid.
+  * Target `Extent` is determined from the source `Extent`.
+  */
 case class TargetGrid(grid: GridExtent) extends ResampleGrid {
-  def apply(source: => RasterExtent): RasterExtent =
-    grid.createAlignedRasterExtent(source.extent)
+  def apply(source: => GridExtent): GridExtent =
+    grid.createAlignedGridExtent(source.extent)
+
+  def reprojectOptions(extent: => Extent,  method: ResampleMethod): Reproject.Options = {
+    Reproject.Options(method = method, parentGridExtent = Some(grid))
+  }
 }
 
+/** Align target pixel grid, cell size, and Extent to given region.
+  * Target `Extent` may be clipped or buffered to given region.
+  */
 case class TargetRegion(region: RasterExtent) extends ResampleGrid {
-  def apply(source: => RasterExtent): RasterExtent =
+  def apply(source: => GridExtent): GridExtent =
     region
+
+  def reprojectOptions(extent: => Extent,  method: ResampleMethod): Reproject.Options = {
+    Reproject.Options(method = method, targetRasterExtent = Some(region))
+  }
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
@@ -52,16 +52,16 @@ case class GeotrellisReprojectRasterSource(
   protected lazy val layerName = baseLayerId.name
   protected lazy val layerIds: Seq[LayerId] = GeotrellisRasterSource.getLayerIdsByName(reader, layerName)
 
-  override lazy val rasterExtent: RasterExtent = reprojectOptions.targetRasterExtent match {
-    case Some(targetRasterExtent) =>
-      targetRasterExtent
-    case None =>
-      ReprojectRasterExtent(baseRasterExtent, transform, reprojectOptions)
-  }
+  override lazy val gridExtent: GridExtent = reprojectOptions.targetRasterExtent match {
+      case Some(targetRasterExtent) =>
+        targetRasterExtent
+      case None =>
+        ReprojectRasterExtent(baseRasterExtent, transform, reprojectOptions)
+    }
 
-  lazy val resolutions: List[RasterExtent] =
-    GeotrellisRasterSource.getResolutions(reader, layerName).map(resolution =>
-      ReprojectRasterExtent(resolution, transform))
+  lazy val resolutions: List[GridExtent] =
+      GeotrellisRasterSource.getResolutions(reader, layerName).map(resolution =>
+        ReprojectRasterExtent(resolution, transform))
 
   @transient private[vlm] lazy val layerId: LayerId = {
     if (reprojectOptions.targetRasterExtent.isDefined
@@ -69,7 +69,7 @@ case class GeotrellisReprojectRasterSource(
       || reprojectOptions.targetCellSize.isDefined)
     {
       // we're asked to match specific target resolution, estimate what resolution we need in source to sample it
-      val estimatedSource = ReprojectRasterExtent(rasterExtent, backTransform, reprojectOptions)
+      val estimatedSource = ReprojectRasterExtent(gridExtent, backTransform, reprojectOptions)
       GeotrellisRasterSource.getClosestLayer(resolutions, layerIds, baseLayerId, estimatedSource.cellSize, strategy)
     } else {
       GeotrellisRasterSource.getClosestLayer(resolutions, layerIds, baseLayerId, baseRasterExtent.cellSize, strategy)
@@ -79,7 +79,7 @@ case class GeotrellisReprojectRasterSource(
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     for {
       _ <- this.extent.intersection(extent)
-      targetRasterExtent = rasterExtent.createAlignedRasterExtent(extent)
+      targetRasterExtent = gridExtent.createAlignedRasterExtent(extent)
       sourceExtent = targetRasterExtent.extent.reprojectAsPolygon(backTransform, 0.001).envelope
       raster <- GeotrellisRasterSource.readIntersecting(reader, layerId, metadata, sourceExtent, bands)
     } yield {
@@ -102,7 +102,7 @@ case class GeotrellisReprojectRasterSource(
     GeotrellisReprojectRasterSource(uri, baseLayerId, bandCount, crs, reprojectOptions, strategy)
 
   def resample(resampleGrid: ResampleGrid, method: ResampleMethod, strategy: OverviewStrategy): RasterSource = {
-    val resampledReprojectOptions = reprojectOptions.copy(method = method, targetRasterExtent = Some(resampleGrid(self.rasterExtent)))
+    val resampledReprojectOptions = resampleGrid.reprojectOptions(this.extent, method)
     GeotrellisReprojectRasterSource(uri, baseLayerId, bandCount, crs, resampledReprojectOptions, strategy)
   }
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisResampleRasterSource.scala
@@ -41,7 +41,7 @@ case class GeotrellisResampleRasterSource(
     baseMetadata.layout.createAlignedGridExtent(baseMetadata.extent).toRasterExtent()
 
   @transient protected lazy val layerId: LayerId =
-    GeotrellisRasterSource.getClosestLayer(resolutions, layerIds, baseLayerId, rasterExtent.cellSize, strategy)
+    GeotrellisRasterSource.getClosestLayer(resolutions, layerIds, baseLayerId, gridExtent.cellSize, strategy)
 
   lazy val metadata = reader.attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](layerId)
 
@@ -50,14 +50,14 @@ case class GeotrellisResampleRasterSource(
   def resampleMethod: Option[ResampleMethod] = Some(method)
 
   lazy val layerName = baseLayerId.name
-  lazy val rasterExtent: RasterExtent = resampleGrid(baseRasterExtent)
-  lazy val resolutions: List[RasterExtent] = GeotrellisRasterSource.getResolutions(reader, layerName)
+  lazy val gridExtent: GridExtent = resampleGrid(baseRasterExtent)
+  lazy val resolutions: List[GridExtent] = GeotrellisRasterSource.getResolutions(reader, layerName)
   lazy val layerIds: Seq[LayerId] = GeotrellisRasterSource.getLayerIdsByName(reader, layerName)
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] =
     GeotrellisRasterSource.readIntersecting(reader, layerId, metadata, extent, bands)
       .map { raster =>
-        val targetRasterExtent = rasterExtent.createAlignedRasterExtent(extent)
+        val targetRasterExtent = gridExtent.createAlignedRasterExtent(extent)
         raster.resample(targetRasterExtent, method)
       }
 

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/GDALResampleRasterSource.scala
@@ -47,7 +47,7 @@ case class GDALResampleRasterSource(
         lazy val rasterExtent: RasterExtent = baseDataset.rasterExtent
         // raster extent won't be calculated if it's not called in the apply function body explicitly
         val targetRasterExtent = {
-          val re = resampleGrid(rasterExtent)
+          val re = resampleGrid(rasterExtent).toRasterExtent
           if(options.alignTargetPixels) re.alignTargetPixels else re
         }
         GDALWarpOptions(

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/package.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/gdal/package.scala
@@ -71,7 +71,7 @@ package object gdal {
         case _ =>
           val re = {
             val targetRasterExtent = resampleGrid(rasterExtent)
-            if(self.alignTargetPixels) targetRasterExtent.alignTargetPixels else targetRasterExtent
+            if(self.alignTargetPixels) targetRasterExtent.toRasterExtent.alignTargetPixels else targetRasterExtent
           }
 
           self.copy(

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/package.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/package.scala
@@ -27,6 +27,8 @@ import geotrellis.spark.io.s3.AmazonS3Client
 
 import org.apache.http.client.utils.URLEncodedUtils
 import com.amazonaws.services.s3.{AmazonS3ClientBuilder, AmazonS3URI}
+import geotrellis.raster._
+import geotrellis.vector._
 
 import java.nio.file.Paths
 import java.net.{URI, URL}

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSummarySpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSummarySpec.scala
@@ -215,7 +215,10 @@ class RasterSummarySpec extends FunSpec with TestEnvironment with BetterRasterMa
     val contextRDD: MultibandTileLayerRDD[SpatialKey] = ContextRDD(tileRDD, metadata)
 
     val res = contextRDD.collect()
-    res.foreach { case (_, v) => v.dimensions shouldBe layout.tileLayout.tileDimensions }
+    res.foreach { case (_, v) =>
+      println(s"v.dimensions: ${v.dimensions}")
+      v.dimensions shouldBe layout.tileLayout.tileDimensions
+    }
     res.length shouldBe rasterRefRdd.count()
     res.length shouldBe 72
 

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSummarySpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSummarySpec.scala
@@ -215,10 +215,7 @@ class RasterSummarySpec extends FunSpec with TestEnvironment with BetterRasterMa
     val contextRDD: MultibandTileLayerRDD[SpatialKey] = ContextRDD(tileRDD, metadata)
 
     val res = contextRDD.collect()
-    res.foreach { case (_, v) =>
-      println(s"v.dimensions: ${v.dimensions}")
-      v.dimensions shouldBe layout.tileLayout.tileDimensions
-    }
+    res.foreach { case (_, v) => v.dimensions shouldBe layout.tileLayout.tileDimensions }
     res.length shouldBe rasterRefRdd.count()
     res.length shouldBe 72
 

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSummarySpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/RasterSummarySpec.scala
@@ -231,7 +231,7 @@ class RasterSummarySpec extends FunSpec with TestEnvironment with BetterRasterMa
 
     cfor(0)(_ < 11, _ + 1) { _ =>
       val reference = GDALRasterSource(inputPath).reproject(targetCRS, method).tileToLayout(layout, method)
-      val RasterExtent(Extent(axmin, aymin, axmax, aymax), acw, ach, acols, arows) = reference.source.rasterExtent
+      val RasterExtent(Extent(axmin, aymin, axmax, aymax), acw, ach, acols, arows) = reference.source.gridExtent
 
       axmin shouldBe exmin +- 1e-5
       aymin shouldBe eymin +- 1e-5

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALReprojectRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALReprojectRasterSourceSpec.scala
@@ -66,7 +66,7 @@ class GDALReprojectRasterSourceSpec extends FunSpec with RasterMatchers with Bet
     def testReprojection(method: ResampleMethod) = {
       val rasterSource = GDALRasterSource(uri)
       val expectedRasterSource = GDALRasterSource(expectedUri(method))
-      val expectedRasterExtent = expectedRasterSource.rasterExtent
+      val expectedRasterExtent = expectedRasterSource.gridExtent.toRasterExtent
       val warpRasterSource = rasterSource.reprojectToRegion(LatLng, expectedRasterExtent, method)
       val testBounds = GridBounds(0, 0, expectedRasterExtent.cols, expectedRasterExtent.rows).split(64,64).toSeq
 

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALWarpOptionsSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/gdal/GDALWarpOptionsSpec.scala
@@ -116,8 +116,8 @@ class GDALWarpOptionsSpec extends FunSpec with RasterMatchers with BetterRasterM
             region = RasterExtent(Extent(-8769160.0, 4257700.0, -8750630.0, 4274460.0), CellSize(22, 22))
           )
 
-      optimizedRawResample.rasterExtent shouldBe rs.rasterExtent
-      originalRawResample.rasterExtent shouldBe rs.rasterExtent
+      optimizedRawResample.rasterExtent.toGridExtent shouldBe rs.gridExtent
+      originalRawResample.rasterExtent.toGridExtent shouldBe rs.gridExtent
     }
   }
 }

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSourceSpec.scala
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package geotrellis.contrib.vlm.geotiff
 
 import geotrellis.contrib.vlm._
 import geotrellis.raster._
+import geotrellis.vector.Extent
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.resample._
 import geotrellis.raster.reproject._
@@ -26,28 +27,41 @@ import geotrellis.spark.testkit._
 import geotrellis.spark.tiling._
 import org.scalatest._
 import java.io.File
-
+import geotrellis.raster.testkit._
 import geotrellis.spark.tiling.LayoutDefinition
 
-class GeoTiffReprojectRasterSourceSpec extends FunSpec with TestEnvironment with BetterRasterMatchers with GivenWhenThen {
+class GeoTiffReprojectRasterSourceSpec extends FunSpec with Matchers with RasterMatchers with BetterRasterMatchers with GivenWhenThen {
   describe("Reprojecting a RasterSource") {
     val uri = s"${new File("").getAbsolutePath()}/src/test/resources/img/aspect-tiled.tif"
     val schemeURI = s"file://$uri"
 
     val rasterSource = GeoTiffRasterSource(schemeURI)
     val sourceTiff = GeoTiffReader.readMultiband(uri)
-    
-    val expectedRasterExtent = {
-      val re = ReprojectRasterExtent(rasterSource.rasterExtent, Transform(rasterSource.crs, LatLng))
-      // stretch target raster extent slightly to avoid default case in ReprojectRasterExtent
-      RasterExtent(re.extent, CellSize(re.cellheight * 1.1, re.cellwidth * 1.1))
+
+
+    // this method expands extent to create ~= grid aligned raster extent
+    def withResolution(re: RasterExtent, targetCellWidth: Double, targetCellHeight: Double): RasterExtent = {
+      val newCols = math.ceil((re.extent.xmax - re.extent.xmin) / targetCellWidth).toInt
+      val newRows = math.ceil((re.extent.ymax - re.extent.ymin) / targetCellHeight).toInt
+
+      val extent = re.extent.copy(
+        ymin = re.extent.ymax - newRows * targetCellHeight,
+        xmax = re.extent.xmin + newCols * targetCellWidth)
+      RasterExtent(extent, targetCellWidth, targetCellHeight, newCols, newRows)
+    }
+
+    val expectedRasterExtent: RasterExtent = {
+      val re = ReprojectRasterExtent(rasterSource.gridExtent, Transform(rasterSource.crs, LatLng)).toRasterExtent
+      withResolution(re, re.cellheight * 1.1, re.cellwidth * 1.1)
     }
 
     def testReprojection(method: ResampleMethod) = {
+      info(s"cols: ${expectedRasterExtent.extent.width / expectedRasterExtent.cellwidth}")
+      info(s"rows: ${expectedRasterExtent.extent.height / expectedRasterExtent.cellheight}")
       val warpRasterSource = rasterSource.reprojectToRegion(LatLng, expectedRasterExtent, method)
-
+      warpRasterSource.gridExtent shouldBe expectedRasterExtent
       warpRasterSource.resolutions.size shouldBe rasterSource.resolutions.size
-      
+
       val testBounds = GridBounds(0, 0, expectedRasterExtent.cols, expectedRasterExtent.rows).split(64,64).toSeq
 
       for (bound <- testBounds) yield {
@@ -56,7 +70,7 @@ class GeoTiffReprojectRasterSourceSpec extends FunSpec with TestEnvironment with
           val testRasterExtent = RasterExtent(
             extent     = targetExtent,
             cellwidth  = expectedRasterExtent.cellwidth,
-            cellheight = expectedRasterExtent.cellheight, 
+            cellheight = expectedRasterExtent.cellheight,
             cols       = bound.width,
             rows       = bound.height
           )
@@ -68,11 +82,13 @@ class GeoTiffReprojectRasterSourceSpec extends FunSpec with TestEnvironment with
 
           val actual = warpRasterSource.read(bound).get
 
+          info("chip dimensions: ${actual.tile.dimensions}")
+          val eps = expectedRasterExtent.cellSize.resolution / 2
           actual.extent.covers(expected.extent) should be (true)
-          actual.rasterExtent.extent.xmin should be (expected.rasterExtent.extent.xmin +- 0.00001)
-          actual.rasterExtent.extent.ymax should be (expected.rasterExtent.extent.ymax +- 0.00001)
-          actual.rasterExtent.cellwidth should be (expected.rasterExtent.cellwidth +- 0.00001)
-          actual.rasterExtent.cellheight should be (expected.rasterExtent.cellheight +- 0.00001)
+          actual.rasterExtent.extent.xmin should be (expected.rasterExtent.extent.xmin +- eps)
+          actual.rasterExtent.extent.ymax should be (expected.rasterExtent.extent.ymax +- eps)
+          actual.rasterExtent.cellwidth should be (expected.rasterExtent.cellwidth +- eps)
+          actual.rasterExtent.cellheight should be (expected.rasterExtent.cellheight +- eps)
 
           withGeoTiffClue(actual, expected, LatLng)  {
             assertRastersEqual(actual, expected)


### PR DESCRIPTION
`RasterExtent` with `Int` for cols/rows can not represent sufficiently large tiled GeoTrellis layer.
This problem has been exposed by addition of `GeoTrellisRasterSource` subclasses.

In the past `GridExtent` has been added to address this sort of problem. While it has `Extent` and `CellSize` it does not explicitly have pixel `cols`/`rows`, allowing it to describe large layers.

This PR is an attempt at refactor to replace usage of `RasterExtent` with `GridExtent` to see if its a feasible or good move for this library.

_Note:_ Subclasses like `GDALRasterSource` and `GeoTiffRasterSource` can assume in their implementation that they will never be reading something that can't be described by `RasterExtent`, so they can cast `GridExtent` to `RasterExtent` and be largely unmodified. Although this may not be the case in the future if we try to read BigTiffs.