### PR TITLE
Typo Fix in GeotrellisReprojectRaterSource.reproject

### DIFF
--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
@@ -99,7 +99,7 @@ case class GeotrellisReprojectRasterSource(
     bounds.toIterator.flatMap(bounds => read(bounds, bands))
 
   def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource =
-    GeotrellisReprojectRasterSource(uri, baseLayerId, bandCount, crs, reprojectOptions, strategy)
+    GeotrellisReprojectRasterSource(uri, baseLayerId, bandCount, targetCRS, reprojectOptions, strategy)
 
   def resample(resampleGrid: ResampleGrid, method: ResampleMethod, strategy: OverviewStrategy): RasterSource = {
     val resampledReprojectOptions = reprojectOptions.copy(method = method, targetRasterExtent = Some(resampleGrid(self.rasterExtent)))


### PR DESCRIPTION
This PR fixes a typo in the `GeotrellisReprojectRasterSource.reproject` method.