### PR TITLE
PolygonalSummary Type Class

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,23 @@ lazy val vlm = project
       """.stripMargin
   )
 
+lazy val summary = project
+  .settings(commonSettings)
+  .settings(
+    organization := "com.azavea.geotrellis",
+    name := "geotrellis-contrib-summary",
+    version := "0.0.1",
+    libraryDependencies ++= Seq(
+      geotrellisRaster,
+      geotrellisVector,
+      simulacrum,
+      scalatest % Test
+    ),
+    Test / fork := true,
+    Test / parallelExecution := false,
+    Test / testOptions += Tests.Argument("-oD")
+  )
+
 lazy val benchmark = (project in file("benchmark"))
   .settings(commonSettings: _*)
   .settings( publish / skip := true)

--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val summary = project
   .settings(
     organization := "com.azavea.geotrellis",
     name := "geotrellis-contrib-summary",
-    version := "0.0.2",
+    version := "0.0.3",
     libraryDependencies ++= Seq(
       geotrellisRaster,
       geotrellisVector,

--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val summary = project
   .settings(
     organization := "com.azavea.geotrellis",
     name := "geotrellis-contrib-summary",
-    version := "0.0.1",
+    version := "0.0.2",
     libraryDependencies ++= Seq(
       geotrellisRaster,
       geotrellisVector,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,6 +41,8 @@ object Dependencies {
   val logging             = "com.typesafe.scala-logging" %% "scala-logging"            % "3.9.0"
   val scalatest           = "org.scalatest"              %% "scalatest"                % "3.0.5"
   val scalactic           = "org.scalactic"              %% "scalactic"                % "3.0.5"
+  val simulacrum          = "com.github.mpilquist"       %% "simulacrum"               % "0.15.0"
+
 
   val catsCore            = "org.typelevel"              %% "cats-core"                % "1.4.0"
   val catsEffect          = "org.typelevel"              %% "cats-effect"              % "1.0.0"

--- a/summary/src/main/scala/geotrellis/contrib/polygonal/CellAccumulator.scala
+++ b/summary/src/main/scala/geotrellis/contrib/polygonal/CellAccumulator.scala
@@ -1,0 +1,11 @@
+package geotrellis.contrib.polygonal
+
+import simulacrum._
+
+/** Accumulate cell values
+ * Note: T instances may be mutable and re-used when adding cell values
+ */
+@typeclass trait CellAccumulator[T] {
+  def add(self: T, v: Int): T
+  def add(self: T, v: Double): T
+}

--- a/summary/src/main/scala/geotrellis/contrib/polygonal/Implicits.scala
+++ b/summary/src/main/scala/geotrellis/contrib/polygonal/Implicits.scala
@@ -1,0 +1,24 @@
+package geotrellis.contrib.polygonal
+
+import geotrellis.vector._
+import geotrellis.raster._
+import cats._
+
+object Implicits {
+  implicit val poloygonalSummaryForRasterTile: PolygonalSummary[Raster[Tile]] = new PolygonalSummary[Raster[Tile]] {
+    // TODO: docstring
+    def polygonalSummary[G <: Geometry, R: CellAccumulator: Monoid](
+      self: Raster[Tile],
+      feature: Feature[G, R]
+    ): Feature[G, R] = {
+      import CellAccumulator.ops._
+      var result: R = feature.data
+      val geom = feature.geom
+      self.rasterExtent.foreach(geom) { (col, row) =>
+        val v = self.tile.getDouble(col, row)
+        if (isData(v)) result = result.add(v)
+      }
+      Feature(geom, result)
+    }
+  }
+}

--- a/summary/src/main/scala/geotrellis/contrib/polygonal/Implicits.scala
+++ b/summary/src/main/scala/geotrellis/contrib/polygonal/Implicits.scala
@@ -2,6 +2,7 @@ package geotrellis.contrib.polygonal
 
 import geotrellis.vector._
 import geotrellis.raster._
+import geotrellis.raster.rasterize.Rasterizer
 import cats._
 
 object Implicits {
@@ -14,10 +15,13 @@ object Implicits {
       import CellAccumulator.ops._
       var result: R = feature.data
       val geom = feature.geom
-      self.rasterExtent.foreach(geom) { (col, row) =>
+
+      val options = Rasterizer.Options(includePartial =  true, sampleType = PixelIsArea)
+      Rasterizer.foreachCellByGeometry(geom, self.rasterExtent, options)  { (col: Int, row: Int) =>
         val v = self.tile.getDouble(col, row)
         if (isData(v)) result = result.add(v)
       }
+
       Feature(geom, result)
     }
   }

--- a/summary/src/main/scala/geotrellis/contrib/polygonal/Implicits.scala
+++ b/summary/src/main/scala/geotrellis/contrib/polygonal/Implicits.scala
@@ -7,16 +7,15 @@ import cats._
 
 object Implicits {
   implicit val poloygonalSummaryForRasterTile: PolygonalSummary[Raster[Tile]] = new PolygonalSummary[Raster[Tile]] {
-    // TODO: docstring
     def polygonalSummary[G <: Geometry, R: CellAccumulator: Monoid](
       self: Raster[Tile],
-      feature: Feature[G, R]
+      feature: Feature[G, R],
+      options: Rasterizer.Options
     ): Feature[G, R] = {
       import CellAccumulator.ops._
       var result: R = feature.data
       val geom = feature.geom
 
-      val options = Rasterizer.Options(includePartial =  true, sampleType = PixelIsArea)
       Rasterizer.foreachCellByGeometry(geom, self.rasterExtent, options)  { (col: Int, row: Int) =>
         val v = self.tile.getDouble(col, row)
         if (isData(v)) result = result.add(v)

--- a/summary/src/main/scala/geotrellis/contrib/polygonal/PolygonalSummary.scala
+++ b/summary/src/main/scala/geotrellis/contrib/polygonal/PolygonalSummary.scala
@@ -3,10 +3,48 @@ package geotrellis.contrib.polygonal
 import cats.Monoid
 import geotrellis.vector._
 import simulacrum._
+import geotrellis.raster.rasterize.Rasterizer
+import geotrellis.raster._
 
 @typeclass trait PolygonalSummary[T] {
-  def polygonalSummary[G <: Geometry, R: CellAccumulator: Monoid](self: T, geometry: G): Feature[G, R] =
-    polygonalSummary(self, Feature(geometry, Monoid[R].empty))
 
-  def polygonalSummary[G <: Geometry, R: CellAccumulator: Monoid](self: T, feature: Feature[G, R]): Feature[G, R]
+  /** Polygonal summary over for pixels under geomery.
+   * Monoid.empty will be used to get the initial value of the accumulator.
+   * Rasterizer.Options are to consider pixels as areas and to include partial intersections.
+   *
+   * @param self Raster-like type containing pixel data
+   * @param feature Geometry for area of summery
+   * @param options Rasterizer options determine which pixels are judged to be intersecting the geometry.
+   */
+  def polygonalSummary[G <: Geometry, R: CellAccumulator: Monoid](self: T, geometry: G): Feature[G, R] =
+    polygonalSummary(self, geometry, Rasterizer.Options(includePartial =  true, sampleType = PixelIsArea))
+
+  /** Polygonal summary over for pixels under geomery.
+   * Monoid.empty will be used to get the initial value of the accumulator.
+   *
+   * @param self Raster-like type containing pixel data
+   * @param feature Geometry for area of summery
+   * @param options Rasterizer options determine which pixels are judged to be intersecting the geometry.
+   */
+  def polygonalSummary[G <: Geometry, R: CellAccumulator: Monoid](self: T, geometry: G, options: Rasterizer.Options): Feature[G, R] =
+    polygonalSummary(self, Feature(geometry, Monoid[R].empty), options)
+
+  /** Polygonal summary over for pixels under geomery.
+   * The feature data value will be used as a starting point of the accumulator.
+   * Rasterizer.Options are to consider pixels as areas and to include partial intersections.
+   *
+   * @param self Raster-like type containing pixel data
+   * @param feature Geometry for area of summery
+   */
+  def polygonalSummary[G <: Geometry, R: CellAccumulator: Monoid](self: T, feature: Feature[G, R]): Feature[G, R] =
+    polygonalSummary(self, feature, Rasterizer.Options(includePartial =  true, sampleType = PixelIsArea))
+
+  /** Polygonal summary over for pixels under geomery.
+   * The feature data value will be used as a starting point of the accumulator.
+   *
+   * @param self Raster-like type containing pixel data
+   * @param feature Geometry for area of summery
+   * @param options Rasterizer options determine which pixels are judged to be intersecting the geometry.
+   */
+  def polygonalSummary[G <: Geometry, R: CellAccumulator: Monoid](self: T, feature: Feature[G, R], options: Rasterizer.Options): Feature[G, R]
 }

--- a/summary/src/main/scala/geotrellis/contrib/polygonal/PolygonalSummary.scala
+++ b/summary/src/main/scala/geotrellis/contrib/polygonal/PolygonalSummary.scala
@@ -1,0 +1,12 @@
+package geotrellis.contrib.polygonal
+
+import cats.Monoid
+import geotrellis.vector._
+import simulacrum._
+
+@typeclass trait PolygonalSummary[T] {
+  def polygonalSummary[G <: Geometry, R: CellAccumulator: Monoid](self: T, geometry: G): Feature[G, R] =
+    polygonalSummary(self, Feature(geometry, Monoid[R].empty))
+
+  def polygonalSummary[G <: Geometry, R: CellAccumulator: Monoid](self: T, feature: Feature[G, R]): Feature[G, R]
+}


### PR DESCRIPTION
Enables usage like:

```scala
val Feature(geom, histogram) = raster.polygonalSummary[Polygon, StreamingHistogram](feature.geom)
```

Core interface is
```scala
  /** Polygonal summary over for pixels under geomery.
   * The feature data value will be used as a starting point of the accumulator.
   *
   * @param self Raster-like type containing pixel data
   * @param feature Geometry for area of summery
   * @param options Rasterizer options determine which pixels are judged to be intersecting the geometry.
   */
  def polygonalSummary[G <: Geometry, R: CellAccumulator: Monoid](self: T, feature: Feature[G, R], options: Rasterizer.Options): Feature[G, R]
```

This is intended as foundation for replacement for polygonal summary code under:
https://github.com/locationtech/geotrellis/tree/master/raster/src/main/scala/geotrellis/raster/summary/polygonal

Main benefits are:
- Exposing `Rasterizer.Options`
- Separate the implementation of cell accumulator (ex: histogram) from the rasterizer code

Future decisions are:
- If this should remain as a type class or method extension using a more fundamental type class.
- If the use of `Monoid` in this interface is justified.
- What does PolygonalSummary over `Raster[MultibandTile]` look like?