### PR TITLE
Added ability to register a read callback on GeoTiff RangeReaders

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val commonSettings = Seq(
     "-language:postfixOps",
     "-language:existentials",
     "-language:experimental.macros",
+//    "-Ywarn-unused-import",
     "-Ypartial-unification" // Required by Cats
   ),
   publishMavenStyle := true,

--- a/gdal/src/test/scala/geotrellis/contrib/vlm/gdal/GDALRasterSourceSpec.scala
+++ b/gdal/src/test/scala/geotrellis/contrib/vlm/gdal/GDALRasterSourceSpec.scala
@@ -17,19 +17,16 @@
 package geotrellis.contrib.vlm.gdal
 
 import geotrellis.contrib.vlm._
-import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.io.geotiff.AutoHigherResolution
 import geotrellis.raster.resample._
-import geotrellis.raster.reproject.Reproject.{Options => ReprojectOptions}
 import geotrellis.raster.testkit._
 import geotrellis.vector._
 import geotrellis.spark._
 import geotrellis.spark.tiling._
 import geotrellis.util._
 
-import com.azavea.gdal.GDALWarp
 import cats.implicits._
 
 import org.scalatest._

--- a/vlm/src/main/resources/reference.conf
+++ b/vlm/src/main/resources/reference.conf
@@ -1,3 +1,6 @@
-vlm.geotiff.s3 {
-  allow-global-read: false
+vlm.geotiff {
+  log-reads: false
+  s3 {
+    allow-global-read: false
+  }
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/Config.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/Config.scala
@@ -16,9 +16,9 @@
 
 package geotrellis.contrib.vlm
 
-import pureconfig._
-
 object Config {
   case class S3Options(allowGlobalRead: Boolean)
+  case class GeoTiffOptions(logReads: Boolean)
   val s3 = pureconfig.loadConfigOrThrow[S3Options]("vlm.geotiff.s3")
+  val geotiff = pureconfig.loadConfigOrThrow[GeoTiffOptions]("vlm.geotiff")
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/ReadCallback.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/ReadCallback.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Astraea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.contrib.vlm.geotiff
+import com.typesafe.scalalogging.LazyLogging
+import geotrellis.util.RangeReader
+
+/** Trait for registering a callback for logging or monitoring range reads.
+  * NB: The callback may be invoked from within a Spark task, and therefore
+  * is serialized along with its closure to executors. */
+trait ReadCallback extends Serializable {
+  def readRange(start: Long, length: Int): Unit
+}
+object ReadCallback extends LazyLogging {
+  case class ReadLogger(label: String) extends ReadCallback {
+    override def readRange(start: Long, length: Int): Unit =
+      logger.info(s"Read $length bytes ($start to ${start + length}) from $label")
+  }
+
+  case class CallbackEnabledRangeReader(delegate: RangeReader, callback: ReadCallback) extends RangeReader {
+    override def totalLength: Long = delegate.totalLength
+    override protected def readClippedRange(start: Long, length: Int): Array[Byte] = {
+      callback.readRange(start, length)
+      delegate.readRange(start, length)
+    }
+  }
+
+  def loggingRangeReader(label: String, delegate: RangeReader): RangeReader =
+    CallbackEnabledRangeReader(delegate, ReadLogger(label))
+}

--- a/vlm/src/test/resources/application.conf
+++ b/vlm/src/test/resources/application.conf
@@ -16,3 +16,6 @@ gdal {
     withShutdownHook: true
   }
 }
+vlm.geotiff {
+  log-reads: false
+}

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/RasterRegionSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/RasterRegionSpec.scala
@@ -32,7 +32,7 @@ class RasterRegionSpec extends FunSpec with TestEnvironment with BetterRasterMat
 
     When("Generating RDD of RasterRegions")
     val rdd: RDD[(SpatialKey, RasterRegion)] with Metadata[TileLayerMetadata[SpatialKey]] = {
-      val srcRdd = sc.parallelize(paths, paths.size).map { uri => new GeoTiffRasterSource(uri) }
+      val srcRdd = sc.parallelize(paths, paths.size).map(GeoTiffRasterSource.apply)
       srcRdd.cache()
 
       val (combinedExtent, commonCellType) =

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffConvertedRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffConvertedRasterSourceSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest._
 class GeoTiffConvertedRasterSourceSpec extends FunSpec with RasterMatchers with BetterRasterMatchers with GivenWhenThen {
   lazy val url = Resource.path("img/aspect-tiled.tif")
 
-  lazy val source: GeoTiffRasterSource = new GeoTiffRasterSource(url)
+  lazy val source: GeoTiffRasterSource = GeoTiffRasterSource(url)
 
   lazy val expectedRaster: Raster[MultibandTile] =
     GeoTiffReader


### PR DESCRIPTION
Helps with debugging header-only metadata and range reads. Also opens the door for the use of Spark accumulators.