### PR TITLE
Improve GDAL Performance on Integration Tests

### DIFF
--- a/gdal/src/it/scala/geotrellis/contrib/vlm/SubsceneReadingIT.scala
+++ b/gdal/src/it/scala/geotrellis/contrib/vlm/SubsceneReadingIT.scala
@@ -27,8 +27,27 @@ import org.scalatest.{FunSpec, Matchers}
 class SubsceneReadingIT extends FunSpec with Matchers with LazyLogging {
   import Timing._
 
-  val sample = "http://s3-us-west-2.amazonaws.com/radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif"
-  // val sample = "s3://radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif"
+  /*
+   * APOLOGY
+   *
+   * In order to find metadata-containing sidecar files, GDAL's
+   * GeoTiff driver takes a listing of the directory containing the
+   * file in question.  This succeeds with `/vsis3/` URIs because S3
+   * supports that kind of thing (the first file in the listing is the
+   * GeoTiff itself, so GDAL extracts the metadata from that file).
+   * For `/vsicurl/` URIs, GDAL hits the URI of the directory and
+   * hopes to get back a sensible response, but S3's http server does
+   * not give one.  It then begins generating filenames, and attempts
+   * to `stat` them which results in a delay.
+   *
+   * For that reason, an http link cannot be used to (fairly) test
+   * GDAL's performance.
+   *
+   * However, one cannot use an S3 link to test GeoTrellis'
+   * performance because of
+   * https://github.com/locationtech/geotrellis/issues/2889
+   */
+  val sample = "https://s3-us-west-2.amazonaws.com/radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif"
   val sample2 = "s3://radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif"
 
   implicit class WithSubExtent(e: Extent) {

--- a/gdal/src/it/scala/geotrellis/contrib/vlm/SubsceneReadingIT.scala
+++ b/gdal/src/it/scala/geotrellis/contrib/vlm/SubsceneReadingIT.scala
@@ -65,7 +65,7 @@ class SubsceneReadingIT extends FunSpec with Matchers with LazyLogging {
 
   describe("GDAL vs GeoTrellis GeoTiff reading") {
 
-    it("should read projected extent with similar performance with GDAL") {
+    it("should be faster reading projected extent with GDAL") {
       val gt = time("GeoTrellis") {
         val src = GeoTiffRasterSource(sample)
         ProjectedExtent(src.extent, src.crs)
@@ -79,7 +79,8 @@ class SubsceneReadingIT extends FunSpec with Matchers with LazyLogging {
       logger.info(gdal.toString)
 
       gt.result should be (gdal.result)
-      gt.durationMillis should be(gdal.durationMillis +- 1000)
+
+      gt.durationMillis shouldBe >= (gdal.durationMillis - 0.05*gt.durationMillis)
     }
 
     it("should be faster reading subextent with GDAL") {
@@ -95,7 +96,7 @@ class SubsceneReadingIT extends FunSpec with Matchers with LazyLogging {
       }
       logger.info(gdal.toString)
 
-      gt.durationMillis shouldBe >= (gdal.durationMillis)
+      gt.durationMillis shouldBe >= (gdal.durationMillis - 0.05*gt.durationMillis)
     }
 
     it("should be faster reading full scene as tiles with GDAL") {
@@ -115,7 +116,7 @@ class SubsceneReadingIT extends FunSpec with Matchers with LazyLogging {
       }
       logger.info(gdal.toString)
 
-      gt.durationMillis shouldBe >= (gdal.durationMillis)
+      gt.durationMillis shouldBe >= (gdal.durationMillis - 0.05*gt.durationMillis)
     }
 
     it("should be faster reading full scene GDAL") {
@@ -131,7 +132,7 @@ class SubsceneReadingIT extends FunSpec with Matchers with LazyLogging {
       }
       logger.info(gdal.toString)
 
-      gt.durationMillis shouldBe >= (gdal.durationMillis)
+      gt.durationMillis shouldBe >= (gdal.durationMillis - 0.05*gt.durationMillis)
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Version {
   val geotrellis     = "2.2.0"
   val geotrellisGdal = "0.18.5"
   val gdal           = Properties.envOrElse("GDAL_VERSION", "2.4.0")
-  val gdalWarp       = "33.803211f"
+  val gdalWarp       = "33.e53ec75"
   val scala          = "2.11.12"
   val crossScala     = Seq(scala, "2.12.8")
   val hadoop         = "2.8.0"


### PR DESCRIPTION
This improves performance on the first test:
```
[info] GDAL vs GeoTrellis GeoTiff reading
18:27:18 SubsceneReadingIT: Elapsed time of GeoTrellis is 1.1300s, producing ProjectedExtent(Extent(3440101.0175691093, -2315767.899836476, 3462532.0983280675, -2294035.527693799),EPSG:3857)
18:27:20 SubsceneReadingIT: Elapsed time of GDAL is 1.5630s, producing ProjectedExtent(Extent(3440101.0175691093, -2315767.899836476, 3462532.0983280675, -2294035.527693799),merc-CS)
[info] - should read projected extent with similar performance with GDAL (2 seconds, 855 milliseconds)
18:27:22 SubsceneReadingIT: Elapsed time of GeoTrellis is 1.9370s, producing Some(372620)
18:27:23 SubsceneReadingIT: Elapsed time of GDAL is 1.3360s, producing Some(372620)
```
but now the third (but never the fourth) test sometimes fails.

~~This is most-likely a configuration issue.~~
```scala
  /*
   * APOLOGY
   *
   * In order to find metadata-containing sidecar files, GDAL's
   * GeoTiff driver takes a listing of the directory containing the
   * file in question.  This succeeds with `/vsis3/` URIs because S3
   * supports that kind of thing (the first file in the listing is the
   * GeoTiff itself, so GDAL extracts the metadata from that file).
   * For `/vsicurl/` URIs, GDAL hits the URI of the directory and
   * hopes to get back a sensible response, but S3's http server does
   * not give one.  It then begins generating filenames, and attempts
   * to `stat` them which results in a delay.
   *
   * For that reason, an http link cannot be used to (fairly) test
   * GDAL's performance.
   *
   * However, one cannot use an S3 link to test GeoTrellis'
   * performance because of
   * https://github.com/locationtech/geotrellis/issues/2889
   */
  val sample = "https://s3-us-west-2.amazonaws.com/radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif"
  val sample2 = "s3://radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif"
```

```bash
src/geotrellis-contrib% ./sbt "project gdal" "it:testOnly geotrellis.contrib.vlm.SubsceneReadingIT"
[info] Loading settings for project geotrellis-contrib-build from plugins.sbt ...
[info] Loading project definition from /home/jmcclain/local/src/geotrellis-contrib/project
[info] Loading settings for project geotrellis-contrib from build.sbt,version.sbt ...
[info] Loading settings for project benchmark from build.sbt ...
[info] Loading settings for project summary from version.sbt ...
[info] Loading settings for project testkit from version.sbt ...
[info] Loading settings for project gdal from version.sbt ...
[info] Loading settings for project vlm from version.sbt ...
[info] Set current project to geotrellis-contrib (in build file:/home/jmcclain/local/src/geotrellis-contrib/)
[info] Set current project to geotrellis-contrib-gdal (in build file:/home/jmcclain/local/src/geotrellis-contrib/)
[warn] Credentials file /home/jmcclain/.sbt/.credentials does not exist
[warn] Credentials file /home/jmcclain/.sbt/.credentials does not exist
[warn] Credentials file /home/jmcclain/.sbt/.credentials does not exist
[info] Compiling 1 Scala source to /home/jmcclain/local/src/geotrellis-contrib/gdal/target/scala-2.11/it-classes ...
[info] Done compiling.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/home/jmcclain/.sbt/boot/scala-2.12.7/org.scala-sbt/sbt/1.2.8/protobuf-java-3.3.1.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[info] SubsceneReadingIT:
[info] GDAL vs GeoTrellis GeoTiff reading
18:21:04 SubsceneReadingIT: Elapsed time of GeoTrellis is 1.7400s, producing ProjectedExtent(Extent(3440101.0175691093, -2315767.899836476, 3462532.0983280675, -2294035.527693799),EPSG:3857)
18:21:05 SubsceneReadingIT: Elapsed time of GDAL is 1.6230s, producing ProjectedExtent(Extent(3440101.0175691093, -2315767.899836476, 3462532.0983280675, -2294035.527693799),merc-CS)
[info] - should be faster reading projected extent with GDAL (3 seconds, 526 milliseconds)
18:21:07 SubsceneReadingIT: Elapsed time of GeoTrellis is 2.0990s, producing Some(372620)
18:21:09 SubsceneReadingIT: Elapsed time of GDAL is 1.1710s, producing Some(372620)
[info] - should be faster reading subextent with GDAL (3 seconds, 272 milliseconds)
18:21:09 SubsceneReadingIT: reading 600 tiles
18:21:56 SubsceneReadingIT: Elapsed time of GeoTrellis is 47.1940s, producing 37194588
18:22:36 SubsceneReadingIT: Elapsed time of GDAL is 40.4830s, producing 37194588
[info] - should be faster reading full scene as tiles with GDAL (1 minute, 27 seconds)
18:23:19 SubsceneReadingIT: Elapsed time of GeoTrellis is 42.2280s, producing 37194588
18:23:19 SubsceneReadingIT: Elapsed time of GDAL is 0.1130s, producing 37194588
[info] - should be faster reading full scene GDAL (42 seconds, 344 milliseconds)
[info] Run completed in 2 minutes, 19 seconds.
[info] Total number of tests run: 4
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 4, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 150 s, completed Apr 2, 2019, 6:23:19 PM
src/geotrellis-contrib% 
```

Closes: https://github.com/geotrellis/geotrellis-contrib/issues/146