### PR TITLE
GeoTrellis 3.0.0-M3, Version 3.11

### DIFF
--- a/gdal/src/test/scala/geotrellis/contrib/vlm/spark/GDALRasterSummarySpec.scala
+++ b/gdal/src/test/scala/geotrellis/contrib/vlm/spark/GDALRasterSummarySpec.scala
@@ -147,7 +147,7 @@ class GDALRasterSummarySpec extends FunSpec with TestEnvironment with BetterRast
     val inputPath = Resource.path("img/aspect-tiled.tif")
     val targetCRS = WebMercator
     val method = Bilinear
-    val layout = LayoutDefinition(GridExtent(Extent(-2.0037508342789244E7, -2.0037508342789244E7, 2.0037508342789244E7, 2.0037508342789244E7), 9.554628535647032, 9.554628535647032), 256)
+    val layout = LayoutDefinition(GridExtent[Int](Extent(-2.0037508342789244E7, -2.0037508342789244E7, 2.0037508342789244E7, 2.0037508342789244E7), CellSize(9.554628535647032, 9.554628535647032)), 256)
     val RasterExtent(Extent(exmin, eymin, exmax, eymax), ecw, ech, ecols, erows) = RasterExtent(Extent(-8769161.632988561, 4257685.794912352, -8750625.653629405, 4274482.8318780195), CellSize(9.554628535647412, 9.554628535646911))
 
     cfor(0)(_ < 11, _ + 1) { _ =>

--- a/gdal/version.sbt
+++ b/gdal/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.0"
+version in ThisBuild := "3.11.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ import scala.util.Properties
 
 
 object Version {
-  val geotrellis     = "3.0.0-M1"
+  val geotrellis     = "3.0.0-M3-SNAPSHOT"
   val geotrellisGdal = "0.18.5"
   val gdal           = Properties.envOrElse("GDAL_VERSION", "2.4.0")
   val gdalWarp       = "33.e53ec75"

--- a/summary/version.sbt
+++ b/summary/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.0"
+version in ThisBuild := "3.11.0"

--- a/testkit/version.sbt
+++ b/testkit/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.0"
+version in ThisBuild := "3.11.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.1-SNAPSHOT"
+version in ThisBuild := "3.11.0"

--- a/vlm/version.sbt
+++ b/vlm/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.0"
+version in ThisBuild := "3.11.0"


### PR DESCRIPTION
Bumping version to `3.x` to make it easier to keep track of this series are those compatible with GeoTrellis 3.x milestones and eventually release.