### PR TITLE
Implement sparse stitch to properly infer missing tiles

### DIFF
--- a/gdal/version.sbt
+++ b/gdal/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.11.0"
+version in ThisBuild := "3.12.0-SNAPSHOT"

--- a/testkit/version.sbt
+++ b/testkit/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.11.0"
+version in ThisBuild := "3.12.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.11.0"
+version in ThisBuild := "3.12.0-SNAPSHOT"

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisRasterSource.scala
@@ -17,15 +17,14 @@
 package geotrellis.contrib.vlm.avro
 
 import geotrellis.contrib.vlm._
-import geotrellis.vector._
 import geotrellis.proj4._
-import geotrellis.raster._
+import geotrellis.raster.io.geotiff.{Auto, AutoHigherResolution, Base, OverviewStrategy}
 import geotrellis.raster.reproject.Reproject
 import geotrellis.raster.resample.ResampleMethod
-import geotrellis.raster.io.geotiff.{Auto, AutoHigherResolution, Base, OverviewStrategy}
-import geotrellis.spark.{LayerId, Metadata, SpatialKey, TileLayerMetadata}
+import geotrellis.raster.{MultibandTile, Tile, _}
 import geotrellis.spark.io._
-import geotrellis.raster.{MultibandTile, Tile}
+import geotrellis.spark.{LayerId, Metadata, SpatialKey, TileLayerMetadata}
+import geotrellis.vector._
 
 case class Layer(id: LayerId, metadata: TileLayerMetadata[SpatialKey], bandCount: Int) {
   /** GridExtent of the data pixels in the layer */
@@ -187,22 +186,40 @@ object GeotrellisRasterSource {
 
   def readIntersecting(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[SpatialKey], extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val tiles = readTiles(reader, layerId, extent, bands)
-    if (tiles.isEmpty)
-      None
-    else
-      Some(tiles.stitch())
+    sparseStitch(tiles, extent)
   }
 
   def read(reader: CollectionLayerReader[LayerId], layerId: LayerId, metadata: TileLayerMetadata[SpatialKey], extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val tiles = readTiles(reader, layerId, extent, bands)
-    if (tiles.isEmpty)
-      None
-    else
-      metadata.extent.intersection(extent) match {
-        case Some(intersectionExtent) =>
-          Some(tiles.stitch().crop(intersectionExtent))
-        case None =>
-          None
-      }
+    metadata.extent.intersection(extent) flatMap { intersectionExtent =>
+      sparseStitch(tiles, intersectionExtent).map(_.crop(intersectionExtent))
+    }
+  }
+
+  /**
+   *  The stitch method in gtcore is unable to handle missing spatialkeys correctly.
+   *  This method works around that problem by attempting to infer any missing tiles
+   **/
+  def sparseStitch(
+    tiles: Seq[(SpatialKey, MultibandTile)] with Metadata[TileLayerMetadata[SpatialKey]],
+    extent: Extent
+  ): Option[Raster[MultibandTile]] = {
+    val md = tiles.metadata
+    val expectedKeys = md
+      .mapTransform(extent)
+      .coordsIter
+      .map { case (x, y) => SpatialKey(x, y) }
+      .toList
+    val actualKeys = tiles.map(_._1)
+    val missingKeys = expectedKeys diff actualKeys
+
+    val missingTiles = missingKeys.map { key =>
+      (key, MultibandTile(ArrayTile.empty(md.cellType, 256, 256)))
+    }
+    val allTiles = tiles.withContext { collection =>
+      collection.toList ::: missingTiles
+    }
+    if (allTiles.isEmpty) None
+    else Some(allTiles.stitch())
   }
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisRasterSource.scala
@@ -214,7 +214,7 @@ object GeotrellisRasterSource {
     val missingKeys = expectedKeys diff actualKeys
 
     val missingTiles = missingKeys.map { key =>
-      (key, MultibandTile(ArrayTile.empty(md.cellType, 256, 256)))
+      (key, MultibandTile(ArrayTile.empty(md.cellType, md.tileLayout.tileCols, md.tileLayout.tileRows)))
     }
     val allTiles = tiles.withContext { collection =>
       collection.toList ::: missingTiles

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
@@ -66,11 +66,13 @@ class GeotrellisReprojectRasterSource(
         lazy val tileBounds = sourceLayer.metadata.mapTransform.extentToBounds(sourceExtent)
         lazy val pixelsRead = (tileBounds.size * sourceLayer.metadata.layout.tileCols * sourceLayer.metadata.layout.tileRows).toDouble
         lazy val pixelsQueried = (targetRasterExtent.cols.toDouble * targetRasterExtent.rows.toDouble)
-        def msg = s"""${GREEN}Read($extent)${RESET} =
-        |\t${BOLD}FROM${RESET} $uri ${sourceLayer.id}
-        |\t${BOLD}TARGET${RESET} ${targetRasterExtent.extent} ${targetRasterExtent.cellSize} @ ${crs}
-        |\t${BOLD}SOURCE${RESET} $sourceExtent ${sourceLayer.metadata.cellSize} @ ${sourceLayer.metadata.crs}
-        |\t${BOLD}READ${RESET} ${pixelsRead/pixelsQueried} read/query ratio for ${tileBounds.size} tiles""".stripMargin
+        def msg = s"""
+          |${GREEN}Read($extent)${RESET} =
+          |\t${BOLD}FROM${RESET} $uri ${sourceLayer.id}
+          |\t${BOLD}SOURCE${RESET} $sourceExtent ${sourceLayer.metadata.cellSize} @ ${sourceLayer.metadata.crs}
+          |\t${BOLD}TARGET${RESET} ${targetRasterExtent.extent} ${targetRasterExtent.cellSize} @ ${crs}
+          |\t${BOLD}READ${RESET} ${pixelsRead/pixelsQueried} read/query ratio for ${tileBounds.size} tiles
+        """.stripMargin
         if (tileBounds.size < 1024) // Assuming 256x256 tiles this would be a very large request
           logger.debug(msg)
         else
@@ -78,8 +80,8 @@ class GeotrellisReprojectRasterSource(
       }
       raster <- GeotrellisRasterSource.readIntersecting(reader, layerId, sourceLayer.metadata, sourceExtent, bands)
     } yield {
-      val reproejcted = raster.reproject(targetRasterExtent, transform, backTransform, reprojectOptions)
-      convertRaster(reproejcted)
+      val reprojected = raster.reproject(targetRasterExtent, transform, backTransform, reprojectOptions)
+      convertRaster(reprojected)
     }
   }
 

--- a/vlm/version.sbt
+++ b/vlm/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.11.0"
+version in ThisBuild := "3.12.0-SNAPSHOT"


### PR DESCRIPTION
This PR implements a sparse stitch function to avoid losing information in case `SpatialKeys` between tiles of imagery are missing. Without this fix, we're susceptible to two bugs if a geotrellis layer has been ingested in pieces (and thus lacks tiles between ingest locations):
1. If an extent is requested which ranges over a meaningful piece of data, that data is liable to be shifted to the top-left in case there are missing tiles prior in row-major order
2. If an extent is requested within the overall extent of a layer but in which there are no tiles, a reader will report that no tile could be grabbed (rather than an empty tile, as one might expect)

Note: I've also bumped the version to be in line with sbt-release convention