### PR TITLE
Round instead of ceil for combining raster extents

### DIFF
--- a/vlm/src/main/scala/geotrellis/contrib/vlm/MosaicRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/MosaicRasterSource.scala
@@ -145,8 +145,8 @@ object MosaicRasterSource {
           throw GeoAttrsError(s"illegal cellheights: ${l.cellheight} and ${r.cellheight}")
 
         val newExtent = l.extent.combine(r.extent)
-        val newRows = Integral[N].fromDouble(math.ceil(newExtent.height / l.cellheight))
-        val newCols = Integral[N].fromDouble(math.ceil(newExtent.width / l.cellwidth))
+        val newRows = Integral[N].fromDouble(math.round(newExtent.height / l.cellheight))
+        val newCols = Integral[N].fromDouble(math.round(newExtent.width / l.cellwidth))
         new GridExtent[N](newExtent, l.cellwidth, l.cellheight, newCols, newRows)
       }
     }


### PR DESCRIPTION
This PR addresses a bug in MosaicRasterSource where sometimes extents won't end up combinable after `ceil`.

Working on testing instructions, just leaving this here for a minute