### PR TITLE
Add CHANGELOG and GitHub pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# Overview
+
+Brief description of what this PR does and why it's important
+
+## Demo
+
+Optional. Screenshots, etc.
+
+## Notes
+
+Optional. Extra context, ancillary topics, alternative strategies that didn't work out, etc.
+
+## Testing Instructions
+
+Optional. Include if there's more specifics than "CI tests should pass".
+
+## Checklist
+
+- [ ] Add entry to CHANGELOG.md
+
+Closes #XXX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- CHANGELOG based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## [3.14.0] - 2019-05-17
+### Added
+- VLM: RasterSourceRDD can accept optional RasterSummary
+
+### Changed
+- GDAL: GDALWarpOptions.convert is now consistent with reproject and resample operations
+- Slick: Do not publish to bintray
+
+### Fixed
+- GDAL: Improve GDALWarpOptions.convert behavior
+- GDAL: GDALRasterSource reports different extent from GeoTiffRasterSource
+- VLM: MosaicRasterSource slow metadata fetches for large mosaics
+- VLM: Combine raster extents with round instead of ceil
+- VLM: RasterSummary.fromSeq improperly constructs CellSize
+
+### Removed
+- GDAL: GDALReprojectRasterSource - this operation is now available as GDALRasterSource.reproject
+- GDAL: GDALResampleRasterSource - this operation is now available as GDALRasterSource.resample
+
+## [3.13.0] - 2019-05-17
+### Added
+- Slick: Project moved to geotrellis-contrib from [geotrellis](https://github.com/locationtech/geotrellis)
+- VLM: GeotrellisRasterSource.sparseStitch to infer missing tiles
+
+### Changed
+- Bump to geotrellis 3.0.0-M3
+
+### Fixed
+- GDAL: Spelng mstke in GDALWarp exception message
+
+## [3.11.0] - 2019-04-08
+### Added
+- GDAL: Run tests in CI
+- GDAL: GDALDataset: Replaces use of GDALWarp.get_token
+
+### Changed
+- Upgrade geotrellis 2.x -> 3.x
+
+### Fixed
+- GDAL: Tests do not pass
+
+[unreleased]: https://github.com/geotrellis/geotrellis-contrib/compare/v3.14.0...HEAD
+[3.14.0]: https://github.com/geotrellis/geotrellis-contrib/compare/v3.13.0...v3.14.0
+[3.13.0]: https://github.com/geotrellis/geotrellis-contrib/compare/v3.11.0...v3.13.0
+[3.11.0]: https://github.com/geotrellis/geotrellis-contrib/compare/v0.11.0...v3.11.0


### PR DESCRIPTION
# Overview

Created with https://github.com/geut/chan: `chan init`,
using https://keepachangelog.com

We reconstructed the log for the most recent `v3.x` tags
that track compatibility with geotrellis 3.0.

For geotrellis 2.x compatibility with backports, see
the `v2.x` series of tags.

The pull request template provides some prompts for helpful contextual information to include on future pull requests and a checklist item to update the new changelog.

## Testing

Please take a look through the release diff links for each of the releases included in the changelog and suggest changes if the notes I came up with need tweaking for clarity. I wasn't involved in any of these changes so some of them were a bit of a shot in the dark.