### PR TITLE
Hadoop ByteReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - CHANGELOG based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+- VLM: Add support for ByteReaders backed by HDFS
 
 ## [3.14.0] - 2019-05-17
 ### Added

--- a/vlm/src/main/resources/reference.conf
+++ b/vlm/src/main/resources/reference.conf
@@ -3,8 +3,4 @@ vlm.geotiff ={
     allow-global-read: false
     region: "us-east-1"
   }
-
-  hdfs = {
-    resources = ["file:///etc/hadoop/conf/core-site.xml", "file:///etc/hadoop/conf/hdfs-site.xml"]
-  }
 }

--- a/vlm/src/main/resources/reference.conf
+++ b/vlm/src/main/resources/reference.conf
@@ -4,5 +4,7 @@ vlm.geotiff ={
     region: "us-east-1"
   }
 
-  hdfs = ["file:///etc/hadoop/conf/core-site.xml", "file:///etc/hadoop/conf/hdfs-site.xml"]
+  hdfs = {
+    resources = ["file:///etc/hadoop/conf/core-site.xml", "file:///etc/hadoop/conf/hdfs-site.xml"]
+  }
 }

--- a/vlm/src/main/resources/reference.conf
+++ b/vlm/src/main/resources/reference.conf
@@ -1,4 +1,8 @@
-vlm.geotiff.s3 {
-  allow-global-read: false
-  region: "us-east-1"
+vlm.geotiff ={
+  s3 = {
+    allow-global-read: false
+    region: "us-east-1"
+  }
+
+  hdfs = ["file:///etc/hadoop/conf/core-site.xml", "file:///etc/hadoop/conf/hdfs-site.xml"]
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/config/HdfsConfig.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/config/HdfsConfig.scala
@@ -21,10 +21,12 @@ import org.apache.hadoop.fs.Path
 import pureconfig.generic.auto._
 import pureconfig._
 
-case class HdfsConfig(resources: List[Path]) {
+import java.net.URI
+
+case class HdfsConfig(resources: List[URI]) {
   def load() = {
     val conf = new Configuration()
-    resources.foreach(conf.addResource)
+    resources.map(new Path(_)).foreach(conf.addResource)
     conf
   }
 }
@@ -34,6 +36,6 @@ object HdfsConfig {
     ConvertHelpers.catchReadError(pathString => new Path(pathString))
   }
 
-  lazy val conf: HdfsConfig = pureconfig.loadConfigOrThrow[HdfsConfig]("vlm.geotiff.hdfs")
+  private lazy val conf: HdfsConfig = pureconfig.loadConfigOrThrow[HdfsConfig]("vlm.geotiff.hdfs")
   implicit def hdfsConfig(obj: HdfsConfig.type): HdfsConfig = conf
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/config/HdfsConfig.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/config/HdfsConfig.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.contrib.vlm.config
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import pureconfig.generic.auto._
+import pureconfig._
+
+case class HdfsConfig(resources: List[Path]) {
+  def load() = {
+    val conf = new Configuration()
+    resources.foreach(conf.addResource)
+    conf
+  }
+}
+
+object HdfsConfig {
+  lazy val conf: HdfsConfig = pureconfig.loadConfigOrThrow[HdfsConfig]("vlm.geotiff.hdfs")
+  implicit def hdfsConfig(obj: HdfsConfig.type): HdfsConfig = conf
+
+  implicit val hadoopPathReader = ConfigReader.fromString[Path] {
+    ConvertHelpers.catchReadError(pathString => new Path(pathString))
+  }
+}

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/config/HdfsConfig.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/config/HdfsConfig.scala
@@ -30,10 +30,10 @@ case class HdfsConfig(resources: List[Path]) {
 }
 
 object HdfsConfig {
-  lazy val conf: HdfsConfig = pureconfig.loadConfigOrThrow[HdfsConfig]("vlm.geotiff.hdfs")
-  implicit def hdfsConfig(obj: HdfsConfig.type): HdfsConfig = conf
-
   implicit val hadoopPathReader = ConfigReader.fromString[Path] {
     ConvertHelpers.catchReadError(pathString => new Path(pathString))
   }
+
+  lazy val conf: HdfsConfig = pureconfig.loadConfigOrThrow[HdfsConfig]("vlm.geotiff.hdfs")
+  implicit def hdfsConfig(obj: HdfsConfig.type): HdfsConfig = conf
 }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/package.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/package.scala
@@ -16,14 +16,17 @@
 
 package geotrellis.contrib
 
-import geotrellis.contrib.vlm.config.S3Config
+import geotrellis.contrib.vlm.config.{S3Config, HdfsConfig}
 import geotrellis.util.{FileRangeReader, StreamingByteReader}
 import geotrellis.spark.io.http.util.HttpRangeReader
 import geotrellis.spark.io.s3.util.S3RangeReader
+import geotrellis.spark.io.hadoop.HdfsRangeReader
 import geotrellis.spark.io.s3.AmazonS3Client
 
 import org.apache.http.client.utils.URLEncodedUtils
 import com.amazonaws.services.s3.{AmazonS3ClientBuilder, AmazonS3URI}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
 
 import java.nio.file.Paths
 import java.net.{URI, URL}
@@ -36,7 +39,7 @@ package object vlm extends vlm.Implicits {
 
     val rr =  javaURI.getScheme match {
       case null =>
-        FileRangeReader(Paths.get(javaURI.toString).toFile)
+        FileRangeReader(Paths.get(uri).toFile)
 
       case "file" =>
         FileRangeReader(Paths.get(javaURI).toFile)
@@ -46,6 +49,9 @@ package object vlm extends vlm.Implicits {
 
       case "http" | "https" =>
         new HttpRangeReader(new URL(uri), false)
+
+      case "hdfs" =>
+        new HdfsRangeReader(new Path(uri), HdfsConfig.load())
 
       case "s3" =>
         val s3Uri = new AmazonS3URI(java.net.URLDecoder.decode(uri, "UTF-8"))

--- a/vlm/src/test/resources/application.conf
+++ b/vlm/src/test/resources/application.conf
@@ -16,3 +16,5 @@ gdal {
     withShutdownHook: true
   }
 }
+
+vlm.geotiff.hdfs.resources = ["file:///etc/hadoop/conf/core-site.xml", "file:///etc/hadoop/conf/hdfs-site.xml"]

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/VlmByteReaderSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/VlmByteReaderSpec.scala
@@ -1,0 +1,16 @@
+package geotrellis.contrib.vlm
+
+import geotrellis.spark.io.hadoop.HdfsRangeReader
+
+import org.scalatest._
+
+import java.net.ConnectException
+
+class VlmByteReaderSpec extends FlatSpec with Matchers {
+  it should "summon an hdfs rangereader" in {
+    // If it gets as far as attempting (and failing) a connection, it created a bytereader
+    assertThrows[ConnectException] {
+      getByteReader("hdfs://localhost:7777/file123").asInstanceOf[HdfsRangeReader]
+    }
+  }
+}


### PR DESCRIPTION
# Overview

This PR adds support for loading a Hadoop `ByteReader` when the provided URI has the authority of `hdfs://`.

## Notes

Instead of attempting to lay out all possible Hadoop configurations (a doomed task), the `geotrellis-contrib` `vlm` configuration optionally includes a list of paths to XML files which is used to generate a Hadoop `Configuration`

## Checklist

- [x] Add entry to CHANGELOG.md

Closes #142
