### PR TITLE
RasterSourceRDD Partition Count Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Summary: Subproject removed. The polygonal summary prototype was moved to GeoTrellis core for the 3.0 release. See: https://github.com/locationtech/geotrellis/blob/master/docs/guide/rasters.rst#polygonal-summary
 
+### Fixed
+- VLM: RasterSourceRDD.read and RasterSourceRDD.tileLayerRDD partition count
+
 ## [3.15.0] - 2019-06-22
 ### Added
 - Fix GDAL resampling with Dimensions resampleGrid

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/spark/RasterSourceRDD.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/spark/RasterSourceRDD.scala
@@ -200,9 +200,15 @@ object RasterSourceRDD {
     val rasterRegionRDD: RDD[(SpatialKey, RasterRegion)] =
       tiledLayoutSourceRDD.flatMap { _.keyedRasterRegions() }
 
+    // The number of partitions estimated by RasterSummary can sometimes be much
+    // lower than what the user set. Therefore, we assume that the larger value
+    // is the optimal number of partitions to use.
+    val partitionCount =
+      math.max(rasterRegionRDD.getNumPartitions, summary.estimatePartitionsNumber)
+
     val tiledRDD: RDD[(SpatialKey, MultibandTile)] =
       rasterRegionRDD
-        .groupByKey(partitioner.getOrElse(SpatialPartitioner(summary.estimatePartitionsNumber)))
+        .groupByKey(partitioner.getOrElse(SpatialPartitioner(partitionCount)))
         .mapValues { iter =>
           MultibandTile(
             iter.flatMap { _.raster.toSeq.flatMap { _.tile.bands } }


### PR DESCRIPTION
# Overview

This PR fixes the number of partitions that the resulting `RDD` has when created via `RasterSourceRDD.read` or `RasterSourceRDD.tileLayerRDD`. Now, it will look at the number of partitions the given `RDD`, and will use that number if it's more than the what is produced by `estimatePartitionsNumber`

## Checklist

- [x] Add entry to CHANGELOG.md

Closes #129 