### PR TITLE
GeoTiffRasterSource Thread Safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - VLM: Correct incomplete reads when using `MosaicRasterSource`
+- VLM: `GeoTiffRasterSource` reads are now thread safe
 
 ### Removed
 - Summary: Subproject removed. The polygonal summary prototype was moved to GeoTrellis core for the 3.0 release. See: https://github.com/locationtech/geotrellis/blob/master/docs/guide/rasters.rst#polygonal-summary

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
@@ -79,8 +79,9 @@ case class GeoTiffRasterSource(
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
     val geoTiffTile = tiff.tile.asInstanceOf[GeoTiffMultibandTile]
     val intersectingBounds: Seq[GridBounds[Int]] =
-      bounds.flatMap(_.intersection(this.gridBounds)).
-      toSeq.map(b => b.toGridType[Int])
+      bounds
+        .flatMap(_.intersection(this.gridBounds)).toSeq
+        .map(b => b.toGridType[Int])
 
     geoTiffTile.crop(intersectingBounds, bands.toArray).map { case (gb, tile) =>
       convertRaster(Raster(tile, gridExtent.extentFor(gb.toGridType[Long], clamp = true)))

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
@@ -57,7 +57,12 @@ case class GeoTiffRasterSource(
       // TODO: shouldn't GridExtent give me Extent for types other than N ?
       Raster(tile, gridExtent.extentFor(gb.toGridType[Long], clamp = false))
     }
-    if (it.hasNext) Some(convertRaster(it.next)) else None
+
+    // tiff.synchronized because we want to reuse tiffs,
+    // it will mean that hte same tiff can be called from a different RasterSource
+    // so it is not enough to lock only inside the current ibject instance and
+    // it is better to lock on a tiff object
+    tiff.synchronized { if (it.hasNext) Some(convertRaster(it.next)) else None }
   }
 
   def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] = {

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
@@ -72,17 +72,19 @@ case class GeoTiffReprojectRasterSource(
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val bounds = gridExtent.gridBoundsFor(extent, clamp = false)
-    val it = readBounds(List(bounds), bands)
-    if (it.hasNext) Some(it.next) else None
+
+    read(bounds, bands)
   }
 
   def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val it = readBounds(List(bounds), bands)
-    if (it.hasNext) Some(it.next) else None
+
+    tiff.synchronized { if (it.hasNext) Some(it.next) else None }
   }
 
   override def readExtents(extents: Traversable[Extent], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
     val bounds = extents.map(gridExtent.gridBoundsFor(_, clamp = true))
+
     readBounds(bounds, bands)
   }
 

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
@@ -44,12 +44,9 @@ case class GeoTiffReprojectRasterSource(
   protected lazy val backTransform = Transform(crs, baseCRS)
 
   override lazy val gridExtent: GridExtent[Long] = reprojectOptions.targetRasterExtent match {
-      case Some(targetRasterExtent) =>
-        targetRasterExtent.toGridType[Long]
-
-        case None =>
-        ReprojectRasterExtent(baseGridExtent, transform, reprojectOptions)
-    }
+    case Some(targetRasterExtent) => targetRasterExtent.toGridType[Long]
+    case None => ReprojectRasterExtent(baseGridExtent, transform, reprojectOptions)
+  }
 
   lazy val resolutions: List[GridExtent[Long]] =
       gridExtent :: tiff.overviews.map(ovr => ReprojectRasterExtent(ovr.rasterExtent.toGridType[Long], transform))
@@ -79,7 +76,7 @@ case class GeoTiffReprojectRasterSource(
   def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val it = readBounds(List(bounds), bands)
 
-    tiff.synchronized { if (it.hasNext) Some(it.next) else None }
+    closestTiffOverview.synchronized { if (it.hasNext) Some(it.next) else None }
   }
 
   override def readExtents(extents: Traversable[Extent], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
@@ -97,8 +94,12 @@ case class GeoTiffReprojectRasterSource(
       val targetRasterExtent = RasterExtent(
         extent = gridExtent.extentFor(targetPixelBounds, clamp = true),
         cols = targetPixelBounds.width.toInt,
-        rows = targetPixelBounds.height.toInt)
-      val sourceExtent = targetRasterExtent.extent.reprojectAsPolygon(backTransform, 0.001).envelope
+        rows = targetPixelBounds.height.toInt
+      )
+
+      // A tmp workaround for https://github.com/locationtech/proj4j/pull/29
+      // Stacktrace details: https://github.com/geotrellis/geotrellis-contrib/pull/206#pullrequestreview-260115791
+      val sourceExtent = Proj4Transform.synchronized(targetRasterExtent.extent.reprojectAsPolygon(backTransform, 0.001).envelope)
       val sourcePixelBounds = closestTiffOverview.rasterExtent.gridBoundsFor(sourceExtent, clamp = true)
       (sourcePixelBounds, targetRasterExtent)
     }}.toMap

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffResampleRasterSource.scala
@@ -70,13 +70,14 @@ case class GeoTiffResampleRasterSource(
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val bounds = gridExtent.gridBoundsFor(extent, clamp = false)
-    val it = readBounds(List(bounds), bands)
-    if (it.hasNext) Some(it.next) else None
+
+    read(bounds, bands)
   }
 
   def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val it = readBounds(List(bounds), bands)
-    if (it.hasNext) Some(it.next) else None
+
+    tiff.synchronized { if (it.hasNext) Some(it.next) else None }
   }
 
   override def readExtents(extents: Traversable[Extent], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffResampleRasterSource.scala
@@ -43,13 +43,13 @@ case class GeoTiffResampleRasterSource(
 
   override lazy val gridExtent: GridExtent[Long] = resampleGrid(tiff.rasterExtent.toGridType[Long])
   lazy val resolutions: List[GridExtent[Long]] = {
-      val ratio = gridExtent.cellSize.resolution / tiff.rasterExtent.cellSize.resolution
-      gridExtent :: tiff.overviews.map { ovr =>
-        val re = ovr.rasterExtent
-        val CellSize(cw, ch) = re.cellSize
-        new GridExtent[Long](re.extent, CellSize(cw * ratio, ch * ratio))
-      }
+    val ratio = gridExtent.cellSize.resolution / tiff.rasterExtent.cellSize.resolution
+    gridExtent :: tiff.overviews.map { ovr =>
+      val re = ovr.rasterExtent
+      val CellSize(cw, ch) = re.cellSize
+      new GridExtent[Long](re.extent, CellSize(cw * ratio, ch * ratio))
     }
+  }
 
   @transient protected lazy val closestTiffOverview: GeoTiff[MultibandTile] =
     tiff.getClosestOverview(gridExtent.cellSize, strategy)
@@ -77,7 +77,7 @@ case class GeoTiffResampleRasterSource(
   def read(bounds: GridBounds[Long], bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val it = readBounds(List(bounds), bands)
 
-    tiff.synchronized { if (it.hasNext) Some(it.next) else None }
+    closestTiffOverview.synchronized { if (it.hasNext) Some(it.next) else None }
   }
 
   override def readExtents(extents: Traversable[Extent], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSourceMultiThreadingSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSourceMultiThreadingSpec.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2019 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package geotrellis.contrib.vlm.geotiff
+
+import geotrellis.contrib.vlm.Resource
+
+import geotrellis.proj4.CRS
+import geotrellis.raster._
+import geotrellis.raster.resample._
+import geotrellis.util._
+
+import org.scalatest.AsyncFunSpec
+
+import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.duration.Duration
+
+
+class GeoTiffRasterSourceMultiThreadingSpec extends AsyncFunSpec {
+  val url = Resource.path("img/aspect-tiled.tif")
+  val source: GeoTiffRasterSource = new GeoTiffRasterSource(url)
+
+  implicit val ec = ExecutionContext.global
+
+  describe("GeoTiffRasterSource should be threadsafe") {
+    it("read") {
+      val res: List[Future[Option[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        source.read()
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+
+    it("readBounds - Option") {
+      val res: List[Future[Option[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        source.read(source.gridBounds, 0 until source.bandCount toSeq)
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+
+    ignore("readBounds - List") {
+      val res: List[Future[List[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        source.readBounds(List(source.gridBounds), 0 until source.bandCount toSeq).toList
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+
+    ignore("readExtents") {
+      val res: List[Future[List[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        source.readExtents(List(source.extent), 0 until source.bandCount toSeq).toList
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+  }
+
+  describe("GeoTiffRasterReprojectSource should be threadsafe") {
+    val reprojected = source.reproject(CRS.fromEpsgCode(4326))
+
+    it("read") {
+      val res: List[Future[Option[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        reprojected.read()
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+
+    it("readBounds - Option") {
+      val res: List[Future[Option[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        reprojected.read(reprojected.gridBounds, 0 until source.bandCount toSeq)
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+
+    ignore("readBounds - List") {
+      val res: List[Future[List[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        reprojected.readBounds(List(reprojected.gridBounds), 0 until source.bandCount toSeq).toList
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+
+    ignore("readExtents") {
+      val res: List[Future[List[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        reprojected.readExtents(List(reprojected.extent), 0 until source.bandCount toSeq).toList
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+  }
+
+  describe("GeoTiffRasterResampleSource should be threadsafe") {
+    val resampled = source.resample((source.cols * 0.95).toInt , (source.rows * 0.95).toInt, NearestNeighbor)
+
+    it("read") {
+      val res: List[Future[Option[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        resampled.read()
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+
+    it("readBounds - Option") {
+      val res: List[Future[Option[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        resampled.read(resampled.gridBounds, 0 until source.bandCount toSeq)
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+
+    ignore("readBounds - List") {
+      val res: List[Future[List[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        resampled.readBounds(List(resampled.gridBounds), 0 until source.bandCount toSeq).toList
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+
+    ignore("readExtents") {
+      val res: List[Future[List[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
+        resampled.readExtents(List(resampled.extent), 0 until source.bandCount toSeq).toList
+      } }
+
+      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
+
+      fres.map { rasters => assert(rasters.size == 101) }
+    }
+  }
+}

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSourceSpec.scala
@@ -17,6 +17,7 @@
 package geotrellis.contrib.vlm.geotiff
 
 import geotrellis.contrib.vlm._
+import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.resample._
@@ -27,7 +28,6 @@ import geotrellis.spark.tiling._
 import geotrellis.util._
 import org.scalatest._
 
-import scala.concurrent.Await
 
 class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRasterMatchers with GivenWhenThen {
   lazy val url = Resource.path("img/aspect-tiled.tif")
@@ -140,24 +140,6 @@ class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRas
 
         layoutSource.source
       }
-    }
-
-    it("RasterSource should be threadsafe") {
-      import scala.concurrent.duration.Duration
-      import scala.concurrent.Future
-      import scala.concurrent.ExecutionContext
-
-      implicit val ec = ExecutionContext.global
-
-      val rs = GeoTiffRasterSource(url)
-
-      val res: List[Future[Option[Raster[MultibandTile]]]] = (0 to 100).toList.map { _ => Future {
-        rs.read()
-      } }
-
-      val fres: Future[List[Raster[MultibandTile]]] = Future.sequence(res).map(_.flatten)
-
-      Await.result(fres, Duration.Inf)
     }
   }
 }

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSourceSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSourceSpec.scala
@@ -17,7 +17,6 @@
 package geotrellis.contrib.vlm.geotiff
 
 import geotrellis.contrib.vlm._
-import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.reader.GeoTiffReader
 import geotrellis.raster.resample._
@@ -26,8 +25,8 @@ import geotrellis.vector._
 import geotrellis.spark._
 import geotrellis.spark.tiling._
 import geotrellis.util._
-import org.scalatest._
 
+import org.scalatest._
 
 class GeoTiffRasterSourceSpec extends FunSpec with RasterMatchers with BetterRasterMatchers with GivenWhenThen {
   lazy val url = Resource.path("img/aspect-tiled.tif")


### PR DESCRIPTION
# Overview

This PR makes reading from `GeoTiffRasterSource`s thread safe by synchronizing the `tiff` objects within these instances. That will ensure that the state of the data doesn't change as it's being accessed by different threads.

## Checklist

- [x] Add entry to CHANGELOG.md
- [x] Tests

Closes https://github.com/locationtech/geotrellis/issues/2954