### PR TITLE
Reprojection Short Circuting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - VLM: `GeoTiffRasterSource` reads are now thread safe
 - VLM: `GeoTiffRasterSource`s will now reuse a tiff instead of rereading
   it when possible.
+- VLM: `RasterSource` will now short circut reprojection if the given
+  source is already in the target CRS.
 
 ### Removed
 - Summary: Subproject removed. The polygonal summary prototype was moved to GeoTrellis core for the 3.0 release. See: https://github.com/locationtech/geotrellis/blob/master/docs/guide/rasters.rst#polygonal-summary

--- a/gdal/src/main/scala/geotrellis/contrib/vlm/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/contrib/vlm/gdal/GDALRasterSource.scala
@@ -70,7 +70,7 @@ case class GDALRasterSource(
       }
   }
 
-  def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource =
+  def reprojection(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource =
     GDALRasterSource(dataPath, options.reproject(gridExtent, crs, targetCRS, reprojectOptions))
 
   def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): RasterSource =

--- a/gdal/src/test/scala/geotrellis/contrib/vlm/gdal/GDALWarpOptionsSpec.scala
+++ b/gdal/src/test/scala/geotrellis/contrib/vlm/gdal/GDALWarpOptionsSpec.scala
@@ -144,7 +144,7 @@ class GDALWarpOptionsSpec extends FunSpec with RasterMatchers with BetterRasterM
       val rs =
         GDALRasterSource(filePath)
           .reproject(
-            targetCRS        = WebMercator,
+            crs              = WebMercator,
             reprojectOptions = ReprojectOptions.DEFAULT.copy(targetCellSize = CellSize(10, 10).some),
             strategy         = AutoHigherResolution
         )

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/MosaicRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/MosaicRasterSource.scala
@@ -91,12 +91,12 @@ trait MosaicRasterSource extends RasterSource {
     *
     * @see [[geotrellis.contrib.vlm.RasterSource.reproject]]
     */
-  def reproject(crs: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy)
-      : RasterSource = MosaicRasterSource(
-    sources map { _.reproject(crs, reprojectOptions, strategy) },
-    crs,
-    gridExtent.reproject(this.crs, crs, reprojectOptions)
-  )
+  def reprojection(crs: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource =
+    MosaicRasterSource(
+      sources map { _.reproject(crs, reprojectOptions, strategy) },
+      crs,
+      gridExtent.reproject(this.crs, crs, reprojectOptions)
+    )
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val rasters = sources map { _.read(extent, bands) }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisRasterSource.scala
@@ -91,7 +91,7 @@ class GeotrellisRasterSource(
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
     bounds.toIterator.flatMap(_.intersection(this.gridBounds).flatMap(read(_, bands)))
 
-  def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource = {
+  def reprojection(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource = {
     if (targetCRS != this.crs) {
       val (closestLayerId, targetGridExtent) = GeotrellisReprojectRasterSource.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
       new GeotrellisReprojectRasterSource(attributeStore, dataPath, closestLayerId, sourceLayers, targetGridExtent, targetCRS, reprojectOptions, targetCellType)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
@@ -97,7 +97,7 @@ class GeotrellisReprojectRasterSource(
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] =
     bounds.toIterator.flatMap(_.intersection(this.gridBounds).flatMap(read(_, bands)))
 
-  def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource = {
+  def reprojection(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource = {
     if (targetCRS == sourceLayer.metadata.crs) {
       val resampleGrid = ResampleGrid.fromReprojectOptions(reprojectOptions).get
       val resampledGridExtent = resampleGrid(this.sourceLayer.gridExtent)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisResampleRasterSource.scala
@@ -93,7 +93,7 @@ class GeotrellisResampleRasterSource(
       .flatMap(read(_, bands))
   }
 
-  def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): GeotrellisReprojectRasterSource = {
+  def reprojection(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): GeotrellisReprojectRasterSource = {
     val (closestLayerId, gridExtent) = GeotrellisReprojectRasterSource.getClosestSourceLayer(targetCRS, sourceLayers, reprojectOptions, strategy)
     new GeotrellisReprojectRasterSource(attributeStore, dataPath, layerId, sourceLayers, gridExtent, targetCRS, reprojectOptions, targetCellType)
   }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
@@ -42,7 +42,7 @@ case class GeoTiffRasterSource(
   def bandCount: Int = tiff.bandCount
   def cellType: CellType = dstCellType.getOrElse(tiff.cellType)
 
-  def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): GeoTiffReprojectRasterSource =
+  def reprojection(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): GeoTiffReprojectRasterSource =
     GeoTiffReprojectRasterSource(dataPath, targetCRS, reprojectOptions, strategy, targetCellType, Some(tiff))
 
   def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): GeoTiffResampleRasterSource =

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
@@ -121,7 +121,7 @@ case class GeoTiffReprojectRasterSource(
     }.map { convertRaster }
   }
 
-  def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource =
+  def reprojection(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource =
     GeoTiffReprojectRasterSource(dataPath, targetCRS, reprojectOptions, strategy, targetCellType, Some(tiff))
 
   def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): RasterSource =

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffResampleRasterSource.scala
@@ -55,7 +55,7 @@ case class GeoTiffResampleRasterSource(
   @transient protected lazy val closestTiffOverview: GeoTiff[MultibandTile] =
     tiff.getClosestOverview(gridExtent.cellSize, strategy)
 
-  def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): GeoTiffReprojectRasterSource =
+  def reprojection(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): GeoTiffReprojectRasterSource =
     new GeoTiffReprojectRasterSource(dataPath, targetCRS, reprojectOptions, strategy, targetCellType) {
       override lazy val gridExtent: GridExtent[Long] = reprojectOptions.targetRasterExtent match {
         case Some(targetRasterExtent) => targetRasterExtent.toGridType[Long]


### PR DESCRIPTION
# Overview

This PR adds logic that checks to see if the target `RasterSource` need to be reprojected. If they don't, then they are either resampled are just returned as-is.

## Checklist

- [x] Add entry to CHANGELOG.md

Closes #102 