### PR TITLE
GeoTiffRasterSource Tiff Reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - VLM: Correct incomplete reads when using `MosaicRasterSource`
 - VLM: `GeoTiffRasterSource` reads are now thread safe
+- VLM: `GeoTiffRasterSource`s will now reuse a tiff instead of rereading
+  it when possible.
 
 ### Removed
 - Summary: Subproject removed. The polygonal summary prototype was moved to GeoTrellis core for the 3.0 release. See: https://github.com/locationtech/geotrellis/blob/master/docs/guide/rasters.rst#polygonal-summary

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
@@ -31,7 +31,7 @@ case class GeoTiffReprojectRasterSource(
   reprojectOptions: Reproject.Options = Reproject.Options.DEFAULT,
   strategy: OverviewStrategy = AutoHigherResolution,
   private[vlm] val targetCellType: Option[TargetCellType] = None,
-  val baseTiff: Option[MultibandGeoTiff] = None
+  private val baseTiff: Option[MultibandGeoTiff] = None
 ) extends RasterSource { self =>
   def resampleMethod: Option[ResampleMethod] = Some(reprojectOptions.method)
 

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
@@ -30,12 +30,13 @@ case class GeoTiffReprojectRasterSource(
   crs: CRS,
   reprojectOptions: Reproject.Options = Reproject.Options.DEFAULT,
   strategy: OverviewStrategy = AutoHigherResolution,
-  private[vlm] val targetCellType: Option[TargetCellType] = None
+  private[vlm] val targetCellType: Option[TargetCellType] = None,
+  val baseTiff: Option[MultibandGeoTiff] = None
 ) extends RasterSource { self =>
   def resampleMethod: Option[ResampleMethod] = Some(reprojectOptions.method)
 
   @transient lazy val tiff: MultibandGeoTiff =
-    GeoTiffReader.readMultiband(getByteReader(dataPath.path), streaming = true)
+    baseTiff.getOrElse(GeoTiffReader.readMultiband(getByteReader(dataPath.path), streaming = true))
 
   protected lazy val baseCRS: CRS = tiff.crs
   protected lazy val baseGridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
@@ -121,11 +122,18 @@ case class GeoTiffReprojectRasterSource(
   }
 
   def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): RasterSource =
-    GeoTiffReprojectRasterSource(dataPath, targetCRS, reprojectOptions, strategy, targetCellType)
+    GeoTiffReprojectRasterSource(dataPath, targetCRS, reprojectOptions, strategy, targetCellType, Some(tiff))
 
   def resample(resampleGrid: ResampleGrid[Long], method: ResampleMethod, strategy: OverviewStrategy): RasterSource =
-    GeoTiffReprojectRasterSource(dataPath, crs, reprojectOptions.copy(method = method, targetRasterExtent = Some(resampleGrid(self.gridExtent).toRasterExtent)), strategy, targetCellType)
+    GeoTiffReprojectRasterSource(
+      dataPath,
+      crs,
+      reprojectOptions.copy(method = method, targetRasterExtent = Some(resampleGrid(self.gridExtent).toRasterExtent)),
+      strategy,
+      targetCellType,
+      Some(tiff)
+    )
 
   def convert(targetCellType: TargetCellType): RasterSource =
-    GeoTiffReprojectRasterSource(dataPath, crs, reprojectOptions, strategy, Some(targetCellType))
+    GeoTiffReprojectRasterSource(dataPath, crs, reprojectOptions, strategy, Some(targetCellType), Some(tiff))
 }

--- a/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSourceMultiThreadingSpec.scala
+++ b/vlm/src/test/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSourceMultiThreadingSpec.scala
@@ -32,7 +32,7 @@ class GeoTiffRasterSourceMultiThreadingSpec extends AsyncFunSpec with Matchers {
   val source = GeoTiffRasterSource(url)
 
   implicit val ec = ExecutionContext.global
-  
+
   val iterations = (0 to 100).toList
 
   /**


### PR DESCRIPTION
# Overview

This PR improves the performance of `GeoTiffRasterSource`s by having the base tiff be an optional constructor. This will prevent the same Tiff being reread multiple times during a job.

## Checklist

- [x] Add entry to CHANGELOG.md

Closes #155