### PR TITLE
Lazy Vals Marked as Transient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - VLM: Correct incomplete reads when using `MosaicRasterSource`
 - VLM: `GeoTiffRasterSource` reads are now thread safe
+- VLM: Marked all `lazy val`s as `@transient` in the `RasterSource`s to
+  prevent NPEs.
 
 ### Removed
 - Summary: Subproject removed. The polygonal summary prototype was moved to GeoTrellis core for the 3.0 release. See: https://github.com/locationtech/geotrellis/blob/master/docs/guide/rasters.rst#polygonal-summary

--- a/gdal/src/main/scala/geotrellis/contrib/vlm/gdal/GDALRasterSource.scala
+++ b/gdal/src/main/scala/geotrellis/contrib/vlm/gdal/GDALRasterSource.scala
@@ -33,31 +33,31 @@ case class GDALRasterSource(
 ) extends RasterSource {
   val path: String = dataPath.path
 
-  lazy val datasetType: Int = options.datasetType
+  @transient lazy val datasetType: Int = options.datasetType
 
   // current dataset
   @transient lazy val dataset: GDALDataset =
     GDALDataset(path, options.toWarpOptionsList.toArray)
 
-  lazy val bandCount: Int = dataset.bandCount
+  @transient lazy val bandCount: Int = dataset.bandCount
 
-  lazy val crs: CRS = dataset.crs
+  @transient lazy val crs: CRS = dataset.crs
 
   // noDataValue from the previous step
-  lazy val noDataValue: Option[Double] = dataset.noDataValue(GDALWarp.SOURCE)
+  @transient lazy val noDataValue: Option[Double] = dataset.noDataValue(GDALWarp.SOURCE)
 
-  lazy val dataType: Int = dataset.dataType
+  @transient lazy val dataType: Int = dataset.dataType
 
-  lazy val cellType: CellType = dstCellType.getOrElse(dataset.cellType)
+  @transient lazy val cellType: CellType = dstCellType.getOrElse(dataset.cellType)
 
-  lazy val gridExtent: GridExtent[Long] = dataset.rasterExtent(datasetType).toGridType[Long]
+  @transient lazy val gridExtent: GridExtent[Long] = dataset.rasterExtent(datasetType).toGridType[Long]
 
   /** Resolutions of available overviews in GDAL Dataset
     *
     * These resolutions could represent actual overview as seen in source file
     * or overviews of VRT that was created as result of resample operations.
     */
-  lazy val resolutions: List[GridExtent[Long]] = dataset.resolutions(datasetType).map(_.toGridType[Long])
+  @transient lazy val resolutions: List[GridExtent[Long]] = dataset.resolutions(datasetType).map(_.toGridType[Long])
 
   override def readBounds(bounds: Traversable[GridBounds[Long]], bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
     bounds

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/RasterSource.scala
@@ -213,13 +213,13 @@ trait RasterSource extends CellGrid[Long] with Serializable {
 
   private[vlm] def targetCellType: Option[TargetCellType]
 
-  protected lazy val dstCellType: Option[CellType] =
+  @transient protected lazy val dstCellType: Option[CellType] =
     targetCellType match {
       case Some(target) => Some(target.cellType)
       case None => None
     }
 
-  protected lazy val convertRaster: Raster[MultibandTile] => Raster[MultibandTile] =
+  @transient protected lazy val convertRaster: Raster[MultibandTile] => Raster[MultibandTile] =
     targetCellType match {
       case Some(target: ConvertTargetCellType) =>
         (raster: Raster[MultibandTile]) => target(raster)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisRasterSource.scala
@@ -60,19 +60,19 @@ class GeotrellisRasterSource(
     this(AttributeStore(dataPath.path), dataPath)
 
 
-  lazy val reader = CollectionLayerReader(attributeStore, dataPath.path)
+  @transient lazy val reader = CollectionLayerReader(attributeStore, dataPath.path)
 
   // read metadata directly instead of searching sourceLayers to avoid unneeded reads
-  lazy val metadata = reader.attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](layerId)
+  @transient lazy val metadata = reader.attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](layerId)
 
-  lazy val gridExtent: GridExtent[Long] = metadata.layout.createAlignedGridExtent(metadata.extent)
+  @transient lazy val gridExtent: GridExtent[Long] = metadata.layout.createAlignedGridExtent(metadata.extent)
 
   def crs: CRS = metadata.crs
 
   def cellType: CellType = dstCellType.getOrElse(metadata.cellType)
 
   // reference to this will fully initilze the sourceLayers stream
-  lazy val resolutions: List[GridExtent[Long]] = sourceLayers.map(_.gridExtent).toList
+  @transient lazy val resolutions: List[GridExtent[Long]] = sourceLayers.map(_.gridExtent).toList
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     GeotrellisRasterSource.read(reader, layerId, metadata, extent, bands).map { convertRaster }

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisReprojectRasterSource.scala
@@ -40,15 +40,15 @@ class GeotrellisReprojectRasterSource(
 ) extends RasterSource with LazyLogging { self =>
   import GeotrellisReprojectRasterSource._
 
-  lazy val reader = CollectionLayerReader(attributeStore, dataPath.path)
+  @transient lazy val reader = CollectionLayerReader(attributeStore, dataPath.path)
 
-  lazy val resolutions: List[GridExtent[Long]] = {
+  @transient lazy val resolutions: List[GridExtent[Long]] = {
     sourceLayers.map { layer =>
       ReprojectRasterExtent(layer.gridExtent, layer.metadata.crs, crs)
     }
   }.toList
 
-  lazy val sourceLayer: Layer = sourceLayers.find(_.id == layerId).get
+  @transient lazy val sourceLayer: Layer = sourceLayers.find(_.id == layerId).get
 
   def bandCount: Int = sourceLayer.bandCount
 

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/avro/GeotrellisResampleRasterSource.scala
@@ -54,13 +54,13 @@ class GeotrellisResampleRasterSource(
   val targetCellType: Option[TargetCellType] = None
 ) extends RasterSource with LazyLogging { self =>
 
-  lazy val reader = CollectionLayerReader(attributeStore, dataPath.path)
+  @transient lazy val reader = CollectionLayerReader(attributeStore, dataPath.path)
 
   /** Source layer metadata  that needs to be resampled */
-  lazy val sourceLayer: Layer = sourceLayers.find(_.id == layerId).get
+  @transient lazy val sourceLayer: Layer = sourceLayers.find(_.id == layerId).get
 
   /** GridExtent of source pixels that needs to be resampled */
-  lazy val sourceGridExtent: GridExtent[Long] = sourceLayer.gridExtent
+  @transient lazy val sourceGridExtent: GridExtent[Long] = sourceLayer.gridExtent
 
   def crs: CRS = sourceLayer.metadata.crs
 
@@ -68,7 +68,7 @@ class GeotrellisResampleRasterSource(
 
   def bandCount: Int = sourceLayer.bandCount
 
-  lazy val resolutions: List[GridExtent[Long]] = sourceLayers.map(_.gridExtent).toList
+  @transient lazy val resolutions: List[GridExtent[Long]] = sourceLayers.map(_.gridExtent).toList
 
   def read(extent: Extent, bands: Seq[Int]): Option[Raster[MultibandTile]] = {
     val tileBounds = sourceLayer.metadata.mapTransform.extentToBounds(extent)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
@@ -34,8 +34,8 @@ case class GeoTiffRasterSource(
   @transient lazy val tiff: MultibandGeoTiff =
     GeoTiffReader.readMultiband(getByteReader(dataPath.path), streaming = true)
 
-  lazy val gridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
-  lazy val resolutions: List[GridExtent[Long]] = gridExtent :: tiff.overviews.map(_.rasterExtent.toGridType[Long])
+  @transient lazy val gridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
+  @transient lazy val resolutions: List[GridExtent[Long]] = gridExtent :: tiff.overviews.map(_.rasterExtent.toGridType[Long])
 
   def crs: CRS = tiff.crs
   def bandCount: Int = tiff.bandCount

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
@@ -37,18 +37,18 @@ case class GeoTiffReprojectRasterSource(
   @transient lazy val tiff: MultibandGeoTiff =
     GeoTiffReader.readMultiband(getByteReader(dataPath.path), streaming = true)
 
-  protected lazy val baseCRS: CRS = tiff.crs
-  protected lazy val baseGridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
+  @transient protected lazy val baseCRS: CRS = tiff.crs
+  @transient protected lazy val baseGridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
 
-  protected lazy val transform = Transform(baseCRS, crs)
-  protected lazy val backTransform = Transform(crs, baseCRS)
+  @transient protected lazy val transform = Transform(baseCRS, crs)
+  @transient protected lazy val backTransform = Transform(crs, baseCRS)
 
-  override lazy val gridExtent: GridExtent[Long] = reprojectOptions.targetRasterExtent match {
+  @transient override lazy val gridExtent: GridExtent[Long] = reprojectOptions.targetRasterExtent match {
     case Some(targetRasterExtent) => targetRasterExtent.toGridType[Long]
     case None => ReprojectRasterExtent(baseGridExtent, transform, reprojectOptions)
   }
 
-  lazy val resolutions: List[GridExtent[Long]] =
+  @transient lazy val resolutions: List[GridExtent[Long]] =
       gridExtent :: tiff.overviews.map(ovr => ReprojectRasterExtent(ovr.rasterExtent.toGridType[Long], transform))
 
   @transient private[vlm] lazy val closestTiffOverview: GeoTiff[MultibandTile] = {

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffResampleRasterSource.scala
@@ -56,7 +56,7 @@ case class GeoTiffResampleRasterSource(
 
   def reproject(targetCRS: CRS, reprojectOptions: Reproject.Options, strategy: OverviewStrategy): GeoTiffReprojectRasterSource =
     new GeoTiffReprojectRasterSource(dataPath, targetCRS, reprojectOptions, strategy, targetCellType) {
-      override lazy val gridExtent: GridExtent[Long] = reprojectOptions.targetRasterExtent match {
+      @transient override lazy val gridExtent: GridExtent[Long] = reprojectOptions.targetRasterExtent match {
         case Some(targetRasterExtent) => targetRasterExtent.toGridType[Long]
         case None => ReprojectRasterExtent(self.gridExtent, this.transform, this.reprojectOptions)
       }


### PR DESCRIPTION
# Overview

This PR marks all `lazy val`s in the `RasterSource`s as `@transient` to help prevent NPEs from occurring in distributed work.

## Checklist

- [x] Add entry to CHANGELOG.md

Closes #82 