### PR TITLE
Release/3.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,41 +6,62 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.17.0] - 2019-07-23
+
 ### Added
+
+- RasterSourceF experimental implementation
+
+### Fixed
+
+- VLM: `GeoTiffRasterSource` reads are now thread safe
+- VLM: `GeoTiffRasterSource`s will now reuse a tiff instead of rereading
+  it when possible.
+
+## [3.16.0] - 2019-07-08
+
+### Added
+
 - VLM: Created the `DataPath` type which the `RasterSource`s now take
 - VLM: Created an SPI interface for `RasterSource`
 - VLM: Use scala-uri library for URI parsing
 
 ### Fixed
+
 - VLM: Correct incomplete reads when using `MosaicRasterSource`
-- VLM: `GeoTiffRasterSource` reads are now thread safe
-- VLM: `GeoTiffRasterSource`s will now reuse a tiff instead of rereading
-  it when possible.
 - VLM: `RasterSource` will now short circut reprojection if the given
   source is already in the target CRS.
-- RasterSourceF experimental implementation
 
 ### Removed
+
 - Summary: Subproject removed. The polygonal summary prototype was moved to GeoTrellis core for the 3.0 release. See: https://github.com/locationtech/geotrellis/blob/master/docs/guide/rasters.rst#polygonal-summary
 
 ### Fixed
+
 - VLM: RasterSourceRDD.read and RasterSourceRDD.tileLayerRDD partition count
 
 ## [3.15.0] - 2019-06-22
+
 ### Added
+
 - Fix GDAL resampling with Dimensions resampleGrid
 - CHANGELOG based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - VLM: Add support for ByteReaders backed by HDFS
 
 ## [3.14.0] - 2019-05-17
+
 ### Added
+
 - VLM: RasterSourceRDD can accept optional RasterSummary
 
 ### Changed
+
 - GDAL: GDALWarpOptions.convert is now consistent with reproject and resample operations
 - Slick: Do not publish to bintray
 
 ### Fixed
+
 - GDAL: Improve GDALWarpOptions.convert behavior
 - GDAL: GDALRasterSource reports different extent from GeoTiffRasterSource
 - VLM: MosaicRasterSource slow metadata fetches for large mosaics
@@ -48,32 +69,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - VLM: RasterSummary.fromSeq improperly constructs CellSize
 
 ### Removed
+
 - GDAL: GDALReprojectRasterSource - this operation is now available as GDALRasterSource.reproject
 - GDAL: GDALResampleRasterSource - this operation is now available as GDALRasterSource.resample
- 
+
 ## [3.13.0] - 2019-05-17
+
 ### Added
+
 - Slick: Project moved to geotrellis-contrib from [geotrellis](https://github.com/locationtech/geotrellis)
 - VLM: GeotrellisRasterSource.sparseStitch to infer missing tiles
 
 ### Changed
+
 - Bump to geotrellis 3.0.0-M3
 
 ### Fixed
+
 - GDAL: Spelng mstke in GDALWarp exception message
 
 ## [3.11.0] - 2019-04-08
+
 ### Added
+
 - GDAL: Run tests in CI
 - GDAL: GDALDataset: Replaces use of GDALWarp.get_token
 
 ### Changed
+
 - Upgrade geotrellis 2.x -> 3.x
 
 ### Fixed
+
 - GDAL: Tests do not pass
 
-[unreleased]: https://github.com/geotrellis/geotrellis-contrib/compare/v3.14.0...HEAD
+[unreleased]: https://github.com/geotrellis/geotrellis-contrib/compare/v3.17.0...HEAD
+[3.17.0]: https://github.com/geotrellis/geotrellis-contrib/compare/v3.16.0...v3.17.0
+[3.16.0]: https://github.com/geotrellis/geotrellis-contrib/compare/v3.15.0...v3.16.0
+[3.15.0]: https://github.com/geotrellis/geotrellis-contrib/compare/v3.14.0...v3.15.0
 [3.14.0]: https://github.com/geotrellis/geotrellis-contrib/compare/v3.13.0...v3.14.0
 [3.13.0]: https://github.com/geotrellis/geotrellis-contrib/compare/v3.11.0...v3.13.0
 [3.11.0]: https://github.com/geotrellis/geotrellis-contrib/compare/v0.11.0...v3.11.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,30 @@
+# Releasing GeoTrellis Contrib
+
+Ensure you have bintray credentials set: https://github.com/sbt/sbt-bintray#credentials
+
+Ensure `master` is up to date.
+
+Create a new release branch `git checkout -b release/x.y.z`
+
+Bump each `version.sbt` to match the version you're releasing.
+
+Update the CHANGELOG. Ensure you've included a new link to the current release at the
+bottom of the file and kept the `[Unreleased]` header at the top.
+
+Commit all your changes.
+
+Time to release!
+```bash
+./sbt publish
+./sbt -212 publish
+./sbt bintrayRelease
+```
+
+Tag the release with `v<x.y.z`, e.g. `v3.17.0` and push the new tag.
+
+Bump each `version.sbt` to x.y.(z + 1)-SNAPSHOT, e.g. if previous release was 
+`3.17.0`, use `3.17.1-SNAPSHOT`. Commit. If a more significant version change is required,
+it can be handled during the next release.
+
+Merge `release/x.y.z` back into `master`. 
+

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val commonSettings = Seq(
 
 lazy val root = Project("geotrellis-contrib", file(".")).
   aggregate(
-    vlm, gdal, slick
+    vlm, gdal, slick, testkit
   ).
   settings(commonSettings: _*).
   settings(publish / skip := true).

--- a/gdal/version.sbt
+++ b/gdal/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.17.0-SNAPSHOT"
+version in ThisBuild := "3.17.0"

--- a/gdal/version.sbt
+++ b/gdal/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.17.0"
+version in ThisBuild := "3.17.1-SNAPSHOT"

--- a/slick/version.sbt
+++ b/slick/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.17.0-SNAPSHOT"
+version in ThisBuild := "3.17.0"

--- a/slick/version.sbt
+++ b/slick/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.17.0"
+version in ThisBuild := "3.17.1-SNAPSHOT"

--- a/testkit/version.sbt
+++ b/testkit/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.17.0-SNAPSHOT"
+version in ThisBuild := "3.17.0"

--- a/testkit/version.sbt
+++ b/testkit/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.17.0"
+version in ThisBuild := "3.17.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.17.0-SNAPSHOT"
+version in ThisBuild := "3.17.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.17.0"
+version in ThisBuild := "3.17.1-SNAPSHOT"

--- a/vlm/version.sbt
+++ b/vlm/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.16.0"
+version in ThisBuild := "3.17.0"

--- a/vlm/version.sbt
+++ b/vlm/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.17.0"
+version in ThisBuild := "3.17.1-SNAPSHOT"


### PR DESCRIPTION
# Overview

This is already published to bintray and the tag `v3.17.0` is available. 

Posting for review of the RELEASING, README and build.sbt changes. Looks like we had a bug in our build.sbt where the testkit project wasn't being published as part of the release process, and it should have been. 

I documented the basics of our release process. Still not automated, but at least now the manual release steps aren't entirely opaque. We still want to push for automated publishing.
