### PR TITLE
Make RasterSources Java serializable

### DIFF
--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
@@ -42,8 +42,9 @@ case class GeoTiffReprojectRasterSource(
   protected lazy val baseCRS: CRS = tiff.crs
   protected lazy val baseGridExtent: GridExtent[Long] = tiff.rasterExtent.toGridType[Long]
 
-  protected lazy val transform = Transform(baseCRS, crs)
-  protected lazy val backTransform = Transform(crs, baseCRS)
+  // TODO: remove transient notation with Proj4 1.1 release
+  @transient protected lazy val transform = Transform(baseCRS, crs)
+  @transient protected lazy val backTransform = Transform(crs, baseCRS)
   
   override lazy val gridExtent: GridExtent[Long] = {
     lazy val reprojectedRasterExtent =


### PR DESCRIPTION
# Overview

This PR marks `transform` fields as `transient` since they are not serializable, for more details see https://github.com/locationtech/proj4j/pull/34

## Test instructions

```bash
# run tests with disabled kryo
GEOTRELLIS_USE_JAVA_SER=TRUE ./sbt 
```

Partially addresses https://github.com/geotrellis/geotrellis-contrib/issues/226
