### PR TITLE
Make baseTiff transient

### DIFF
--- a/vlm/src/main/scala/geotrellis/contrib/vlm/effect/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/effect/geotiff/GeoTiffReprojectRasterSource.scala
@@ -43,13 +43,13 @@ case class GeoTiffReprojectRasterSource[F[_]: Monad: UnsafeLift](
   strategy: OverviewStrategy = AutoHigherResolution,
   errorThreshold: Double = 0.125,
   private[vlm] val targetCellType: Option[TargetCellType] = None,
-  private[vlm] val baseTiff: Option[F[MultibandGeoTiff]] = None
+  @transient private[vlm] val baseTiff: Option[F[MultibandGeoTiff]] = None
 ) extends RasterSourceF[F] {
   def name: GeoTiffPath = dataPath
 
   // memoize tiff, not useful only in a local fs case
   @transient lazy val tiff: MultibandGeoTiff = GeoTiffReader.readMultiband(RangeReader(dataPath.value), streaming = true)
-  @transient lazy val tiffF: F[MultibandGeoTiff] = baseTiff.getOrElse(UnsafeLift[F].apply(tiff))
+  @transient lazy val tiffF: F[MultibandGeoTiff] = Option(baseTiff).flatten.getOrElse(UnsafeLift[F].apply(tiff))
 
   def bandCount: F[Int] = tiffF.map(_.bandCount)
   def cellType: F[CellType] = dstCellType.fold(tiffF.map(_.cellType))(Monad[F].pure)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/effect/geotiff/GeoTiffResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/effect/geotiff/GeoTiffResampleRasterSource.scala
@@ -39,14 +39,14 @@ case class GeoTiffResampleRasterSource[F[_]: Monad: UnsafeLift](
   method: ResampleMethod = NearestNeighbor,
   strategy: OverviewStrategy = AutoHigherResolution,
   private[vlm] val targetCellType: Option[TargetCellType] = None,
-  private[vlm] val baseTiff: Option[F[MultibandGeoTiff]] = None
+  @transient private[vlm] val baseTiff: Option[F[MultibandGeoTiff]] = None
 ) extends RasterSourceF[F] {
   def resampleMethod: Option[ResampleMethod] = Some(method)
   def name: GeoTiffPath = dataPath
 
   // memoize tiff, not useful only in a local fs case
   @transient lazy val tiff: MultibandGeoTiff = GeoTiffReader.readMultiband(RangeReader(dataPath.value), streaming = true)
-  @transient lazy val tiffF: F[MultibandGeoTiff] = baseTiff.getOrElse(UnsafeLift[F].apply(tiff))
+  @transient lazy val tiffF: F[MultibandGeoTiff] = Option(baseTiff).flatten.getOrElse(UnsafeLift[F].apply(tiff))
 
   def bandCount: F[Int] = tiffF.map(_.bandCount)
   def cellType: F[CellType] = dstCellType.fold(tiffF.map(_.cellType))(Monad[F].pure)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffRasterSource.scala
@@ -28,12 +28,12 @@ import geotrellis.util.RangeReader
 case class GeoTiffRasterSource(
   dataPath: GeoTiffPath,
   private[vlm] val targetCellType: Option[TargetCellType] = None,
-  private[vlm] val baseTiff: Option[MultibandGeoTiff] = None
+  @transient private[vlm] val baseTiff: Option[MultibandGeoTiff] = None
 ) extends RasterSource {
   def name: GeoTiffPath = dataPath
 
   @transient lazy val tiff: MultibandGeoTiff =
-    baseTiff.getOrElse(GeoTiffReader.readMultiband(RangeReader(dataPath.value), streaming = true))
+    Option(baseTiff).flatten.getOrElse(GeoTiffReader.readMultiband(RangeReader(dataPath.value), streaming = true))
 
   def bandCount: Int = tiff.bandCount
   def cellType: CellType = dstCellType.getOrElse(tiff.cellType)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffReprojectRasterSource.scala
@@ -34,12 +34,12 @@ case class GeoTiffReprojectRasterSource(
   strategy: OverviewStrategy = AutoHigherResolution,
   errorThreshold: Double = 0.125,
   private[vlm] val targetCellType: Option[TargetCellType] = None,
-  private[vlm] val baseTiff: Option[MultibandGeoTiff] = None
+  @transient private[vlm] val baseTiff: Option[MultibandGeoTiff] = None
 ) extends RasterSource {
   def name: GeoTiffPath = dataPath
 
   @transient lazy val tiff: MultibandGeoTiff =
-    baseTiff.getOrElse(GeoTiffReader.readMultiband(RangeReader(dataPath.value), streaming = true))
+    Option(baseTiff).flatten.getOrElse(GeoTiffReader.readMultiband(RangeReader(dataPath.value), streaming = true))
 
   def bandCount: Int = tiff.bandCount
   def cellType: CellType = dstCellType.getOrElse(tiff.cellType)

--- a/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffResampleRasterSource.scala
+++ b/vlm/src/main/scala/geotrellis/contrib/vlm/geotiff/GeoTiffResampleRasterSource.scala
@@ -32,13 +32,13 @@ case class GeoTiffResampleRasterSource(
   method: ResampleMethod = NearestNeighbor,
   strategy: OverviewStrategy = AutoHigherResolution,
   private[vlm] val targetCellType: Option[TargetCellType] = None,
-  private[vlm] val baseTiff: Option[MultibandGeoTiff] = None
+  @transient private[vlm] val baseTiff: Option[MultibandGeoTiff] = None
 ) extends RasterSource {
   def resampleMethod: Option[ResampleMethod] = Some(method)
   def name: GeoTiffPath = dataPath
 
   @transient lazy val tiff: MultibandGeoTiff =
-    baseTiff.getOrElse(GeoTiffReader.readMultiband(RangeReader(dataPath.value), streaming = true))
+    Option(baseTiff).flatten.getOrElse(GeoTiffReader.readMultiband(RangeReader(dataPath.value), streaming = true))
 
   def bandCount: Int = tiff.bandCount
   def cellType: CellType = dstCellType.getOrElse(tiff.cellType)


### PR DESCRIPTION
# Overview

Addresses https://github.com/geotrellis/geotrellis-contrib/issues/226 as well. 
In some cases GeoTiffs would not be serializable due to having non serializable byte buffers. 
Probably a better solution would be to improve GeoTiff class and make it serializable, so it is probably a temporal solution.

Closes #226
