### PR TITLE
Fix CI publishing failing with Java SSL handshake exceptions to repo.locationtech.org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,15 +34,26 @@ aliases:
         command: ./scripts/cipublish
 
   # Build environments
-  - &openjdk8-scala2_11_12_environment
+  - &machine-openjdk8-scala2_11_12-environment
     machine:
       image: ubuntu-1604:201903-01
     environment:
       SCALA_VERSION: 2.11.12
 
-  - &openjdk8-scala2_12_8_environment
+  - &machine-openjdk8-scala2_12_8-environment
     machine:
       image: ubuntu-1604:201903-01
+    environment:
+      SCALA_VERSION: 2.12.8
+  - &openjdk8-scala2_11_12-environment
+    docker:
+      - image: circleci/openjdk:8-jdk
+    environment:
+      SCALA_VERSION: 2.11.12
+
+  - &openjdk8-scala2_12_8-environment
+    docker:
+      - image: circleci/openjdk:8-jdk
     environment:
       SCALA_VERSION: 2.12.8
 
@@ -87,18 +98,20 @@ workflows:
                 - /hotfix\/.*/
 
 jobs:
+  # Execute cibuild in machine executor so we can use our existing
+  # docker-compose test setup
   "openjdk8-scala2.11.12":
-    <<: *openjdk8-scala2_11_12_environment
+    <<: *machine-openjdk8-scala2_11_12-environment
     steps: *run_cibuild
 
   "openjdk8-scala2.12.8":
-    <<: *openjdk8-scala2_12_8_environment
+    <<: *machine-openjdk8-scala2_12_8-environment
     steps: *run_cibuild
 
   "openjdk8-scala2.11.12_deploy":
-    <<: *openjdk8-scala2_11_12_environment
+    <<: *openjdk8-scala2_11_12-environment
     steps: *run_cipublish
 
   "openjdk8-scala2.12.8_deploy":
-    <<: *openjdk8-scala2_12_8_environment
+    <<: *openjdk8-scala2_12_8-environment
     steps: *run_cipublish


### PR DESCRIPTION
## Overview

`./scripts/cipublish` uses native java + ./sbt because otherwise we need to install and mount gpg information in the sbt container when publishing, which is a hassle. Native Java on the latest machine executor available in CircleCI happens to have a version of Java too old to have the cipher repo.locationtech.org uses. So here we update the version of Java on the CI machine executor rather than do the configuration necessary to wrap GPG and our keys up in a container with SBT. Code comments and git log have an extra bit of detail.

Connects #222 
