### PR TITLE
Receive GPG key while publishing artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ workflows:
                 - develop
                 - /release\/.*/
                 - /hotfix\/.*/
+                - feature/jrb/receive-gpg-key
 
 jobs:
   # Execute cibuild in machine executor so we can use our existing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,10 @@ aliases:
     - run:
         name: "Import signing key"
         command: |
+          gpg --keyserver keyserver.ubuntu.com \
+            --recv-keys 0x13E9AA1D8153E95E && \
           echo "${GPG_KEY}" | base64 -d > signing_key.asc && \
-          gpg --batch \
-            --passphrase "${GPG_PASSPHRASE}" \
-            --import signing_key.asc
+          gpg --import signing_key.asc
     - run:
         name: Executing cipublish
         command: ./scripts/cipublish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Receive GPG key while publishing artifacts [#243](https://github.com/geotrellis/geotrellis-contrib/pull/243)
+
 ### Changed
 
 - Artifacts are published to https://oss.sonatype.org automatically via CircleCI


### PR DESCRIPTION
## Overview

We've [added](http://keyserver.ubuntu.com/pks/lookup?search=0x52D6103D31A87CB6&fingerprint=on&op=index) a new signature to the GeoTrellis public key to extend the validity of the signing subkey. 

This change set receives the latest copy of the public key at the start of the `cipublish` build stage, allowing us to "renew" the key in the future without needing to update the key pair stored in CircleCI secrets.

### Checklist

- [x] Description of PR is in an appropriate section of the CHANGELOG and grouped with similar changes if possible

## Testing Instructions

Builds are failing due to https://github.com/locationtech/geotrellis/issues/3251.

See successful CircleCI builds from other repositories:

- https://github.com/geotrellis/geotrellis-server/pull/271
- https://github.com/geotrellis/maml/pull/122

Resolves https://github.com/azavea/operations/issues/446
